### PR TITLE
Improve scan file memory load for

### DIFF
--- a/CavernSeer.xcodeproj/project.pbxproj
+++ b/CavernSeer.xcodeproj/project.pbxproj
@@ -78,6 +78,11 @@
 		7E9C2D0824B8116500B9FC44 /* icon-1024.png in Resources */ = {isa = PBXBuildFile; fileRef = 7E9C2D0424B8116500B9FC44 /* icon-1024.png */; };
 		7E9C2D0924B8116500B9FC44 /* icon-58.png in Resources */ = {isa = PBXBuildFile; fileRef = 7E9C2D0524B8116500B9FC44 /* icon-58.png */; };
 		7E9C2D0B24BA283400B9FC44 /* ProjectedMiniWorldRender.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E9C2D0A24BA283400B9FC44 /* ProjectedMiniWorldRender.swift */; };
+		7E9CF3CC259D3D5F0036F6F7 /* PreviewStoredFileProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E9CF3CB259D3D5F0036F6F7 /* PreviewStoredFileProtocol.swift */; };
+		7E9CF3D1259D3DDA0036F6F7 /* StoredFileProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E9CF3D0259D3DDA0036F6F7 /* StoredFileProtocol.swift */; };
+		7E9CF3D6259D3DEB0036F6F7 /* SavedStoredFileProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E9CF3D5259D3DEB0036F6F7 /* SavedStoredFileProtocol.swift */; };
+		7E9CF3DB259D5D140036F6F7 /* PreviewScanModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E9CF3DA259D5D140036F6F7 /* PreviewScanModel.swift */; };
+		7E9CF3EE259D6C6F0036F6F7 /* PreviewProjectModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E9CF3ED259D6C6F0036F6F7 /* PreviewProjectModel.swift */; };
 		7EAE9CCD2561B88600EA66D0 /* SettingsTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EAE9CCC2561B88600EA66D0 /* SettingsTabView.swift */; };
 		7EAE9CD52561C6B700EA66D0 /* SettingsKeyEnum.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EAE9CD42561C6B700EA66D0 /* SettingsKeyEnum.swift */; };
 		7EAE9CE92561FF5900EA66D0 /* UserDefaults+color.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EAE9CE82561FF5900EA66D0 /* UserDefaults+color.swift */; };
@@ -182,6 +187,11 @@
 		7E9C2D0424B8116500B9FC44 /* icon-1024.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "icon-1024.png"; sourceTree = "<group>"; };
 		7E9C2D0524B8116500B9FC44 /* icon-58.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "icon-58.png"; sourceTree = "<group>"; };
 		7E9C2D0A24BA283400B9FC44 /* ProjectedMiniWorldRender.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectedMiniWorldRender.swift; sourceTree = "<group>"; };
+		7E9CF3CB259D3D5F0036F6F7 /* PreviewStoredFileProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewStoredFileProtocol.swift; sourceTree = "<group>"; };
+		7E9CF3D0259D3DDA0036F6F7 /* StoredFileProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoredFileProtocol.swift; sourceTree = "<group>"; };
+		7E9CF3D5259D3DEB0036F6F7 /* SavedStoredFileProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SavedStoredFileProtocol.swift; sourceTree = "<group>"; };
+		7E9CF3DA259D5D140036F6F7 /* PreviewScanModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewScanModel.swift; sourceTree = "<group>"; };
+		7E9CF3ED259D6C6F0036F6F7 /* PreviewProjectModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewProjectModel.swift; sourceTree = "<group>"; };
 		7EAE9CCC2561B88600EA66D0 /* SettingsTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsTabView.swift; sourceTree = "<group>"; };
 		7EAE9CD42561C6B700EA66D0 /* SettingsKeyEnum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsKeyEnum.swift; sourceTree = "<group>"; };
 		7EAE9CE82561FF5900EA66D0 /* UserDefaults+color.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+color.swift"; sourceTree = "<group>"; };
@@ -281,6 +291,9 @@
 			isa = PBXGroup;
 			children = (
 				7E4003B424AD7B7500B709BD /* DrawableProtocol.swift */,
+				7E9CF3D0259D3DDA0036F6F7 /* StoredFileProtocol.swift */,
+				7E9CF3CB259D3D5F0036F6F7 /* PreviewStoredFileProtocol.swift */,
+				7E9CF3D5259D3DEB0036F6F7 /* SavedStoredFileProtocol.swift */,
 			);
 			path = protocols;
 			sourceTree = "<group>";
@@ -420,8 +433,10 @@
 				7E4003B624AD8FD500B709BD /* Entities */,
 				7E6C0EF024A838A000129E8C /* ScanStore.swift */,
 				7E6C0EF224A838E200129E8C /* SavedScanModel.swift */,
+				7E9CF3DA259D5D140036F6F7 /* PreviewScanModel.swift */,
 				7E0C5EE424C90746001C0D0E /* ProjectStore.swift */,
 				7E0C5EE624C90D86001C0D0E /* SavedProjectModel.swift */,
+				7E9CF3ED259D6C6F0036F6F7 /* PreviewProjectModel.swift */,
 				7E0C5EEA24C93446001C0D0E /* StoreProtocol.swift */,
 				7E0C5EF524CE580B001C0D0E /* FileOpener.swift */,
 				7E23DB112544FDA800BABB52 /* ObjSerializer.swift */,
@@ -692,10 +707,14 @@
 				7E9C2CF724B6937B00B9FC44 /* ScanShareSheet.swift in Sources */,
 				7E4003B024AD5DC600B709BD /* DrawOverlay.swift in Sources */,
 				7E9C2CE624B3FBFE00B9FC44 /* SavedScanListView.swift in Sources */,
+				7E9CF3D6259D3DEB0036F6F7 /* SavedStoredFileProtocol.swift in Sources */,
 				7E6C0EE924A82CC700129E8C /* ScannerTabView.swift in Sources */,
 				7E4888342557534900894D43 /* ElevationProjectedMiniWorldRender.swift in Sources */,
+				7E9CF3D1259D3DDA0036F6F7 /* StoredFileProtocol.swift in Sources */,
 				7E0C5EF924CE5F0B001C0D0E /* FileOpenError.swift in Sources */,
 				7E6C0EED24A834E200129E8C /* SnapshotAnchor.swift in Sources */,
+				7E9CF3CC259D3D5F0036F6F7 /* PreviewStoredFileProtocol.swift in Sources */,
+				7E9CF3DB259D5D140036F6F7 /* PreviewScanModel.swift in Sources */,
 				7E0C5EE524C90746001C0D0E /* ProjectStore.swift in Sources */,
 				7EAE9CCD2561B88600EA66D0 /* SettingsTabView.swift in Sources */,
 				7E0C5ED524BACECE001C0D0E /* MergeTool.swift in Sources */,
@@ -703,6 +722,7 @@
 				7E9C2CE424B3F99800B9FC44 /* SavedScanListScrollView.swift in Sources */,
 				7E6C0EAE24A800C200129E8C /* SceneDelegate.swift in Sources */,
 				7E9C2CF124B55FE800B9FC44 /* SavedScanDetailAdvanced.swift in Sources */,
+				7E9CF3EE259D6C6F0036F6F7 /* PreviewProjectModel.swift in Sources */,
 				7EAE9CE92561FF5900EA66D0 /* UserDefaults+color.swift in Sources */,
 				7E6C0EF724A938ED00129E8C /* ScannerModel.swift in Sources */,
 				7E6C0EF124A838A000129E8C /* ScanStore.swift in Sources */,

--- a/CavernSeer/ContentView.swift
+++ b/CavernSeer/ContentView.swift
@@ -14,7 +14,7 @@ struct ContentView: View {
     @EnvironmentObject var fileOpener: FileOpener
 
     let tabs: [TabProtocol] = [
-        ProjectListTab(),
+//        ProjectListTab(),
         ScanListTab(),
         ScannerTab(),
         SettingsTab(),

--- a/CavernSeer/Models/PreviewProjectModel.swift
+++ b/CavernSeer/Models/PreviewProjectModel.swift
@@ -1,0 +1,40 @@
+//
+//  PreviewProjectModel.swift
+//  CavernSeer
+//
+//  Created by Samuel Grush on 12/30/20.
+//  Copyright © 2020 Samuel K. Grush. All rights reserved.
+//
+
+import Foundation
+
+struct PreviewProjectModel: Identifiable, Hashable, PreviewStoredFileProtocol {
+
+    let id: String
+    let url: URL
+
+    let name: String
+
+    let fileSize: Int64
+
+    let imageData: Data?
+
+    init(url: URL) throws {
+        self.url = url
+        self.id = url.deletingPathExtension().lastPathComponent
+
+        let data = try Data(contentsOf: url)
+        self.fileSize = Int64(data.count)
+        guard let project = try NSKeyedUnarchiver.unarchivedObject(
+                ofClass: ProjectFile.self,
+                from: data
+            )
+        else { throw FileOpenError.noFileInArchive(url: url) }
+
+        self.name = project.name
+        self.imageData = project.scans.first?.scan.startSnapshot?.imageData
+
+    }
+
+    func getURL() -> URL { self.url }
+}

--- a/CavernSeer/Models/PreviewProjectModel.swift
+++ b/CavernSeer/Models/PreviewProjectModel.swift
@@ -35,6 +35,4 @@ struct PreviewProjectModel: Identifiable, Hashable, PreviewStoredFileProtocol {
         self.imageData = project.scans.first?.scan.startSnapshot?.imageData
 
     }
-
-    func getURL() -> URL { self.url }
 }

--- a/CavernSeer/Models/PreviewScanModel.swift
+++ b/CavernSeer/Models/PreviewScanModel.swift
@@ -34,6 +34,4 @@ struct PreviewScanModel: Identifiable, Hashable, PreviewStoredFileProtocol {
         self.name = scan.name
         self.imageData = scan.startSnapshot?.imageData
     }
-
-    func getURL() -> URL { self.url }
 }

--- a/CavernSeer/Models/PreviewScanModel.swift
+++ b/CavernSeer/Models/PreviewScanModel.swift
@@ -1,0 +1,39 @@
+//
+//  PreviewScanModel.swift
+//  CavernSeer
+//
+//  Created by Samuel Grush on 12/30/20.
+//  Copyright © 2020 Samuel K. Grush. All rights reserved.
+//
+
+import Foundation
+
+struct PreviewScanModel: Identifiable, Hashable, PreviewStoredFileProtocol {
+
+    let id: String
+    let url: URL
+
+    let name: String
+
+    let fileSize: Int64
+
+    let imageData: Data?
+
+    init(url: URL) throws {
+        self.url = url
+        self.id = url.deletingPathExtension().lastPathComponent
+
+        let data = try Data(contentsOf: url)
+        self.fileSize = Int64(data.count)
+        guard let scan = try NSKeyedUnarchiver.unarchivedObject(
+                ofClass: ScanFile.self,
+                from: data
+            )
+        else { throw FileOpenError.noFileInArchive(url: url) }
+
+        self.name = scan.name
+        self.imageData = scan.startSnapshot?.imageData
+    }
+
+    func getURL() -> URL { self.url }
+}

--- a/CavernSeer/Models/ProjectStore.swift
+++ b/CavernSeer/Models/ProjectStore.swift
@@ -11,14 +11,17 @@ import Foundation
 final class ProjectStore : StoreProtocol {
     typealias FileType = ProjectFile
     typealias ModelType = SavedProjectModel
+    typealias PreviewType = PreviewProjectModel
 
-    var directoryName: String { "projects" }
-    var filePrefix: String { "proj" }
-    var fileExtension: String { FileType.fileExtension }
+    let directoryName: String = "projects"
+    let filePrefix: String = "proj"
+    let fileExtension: String = FileType.fileExtension
     var directory: URL!
 
+    var cachedModelData: [ModelType] = []
+
     @Published
-    var modelData: [SavedProjectModel] = []
+    var previews: [PreviewType] = []
 
     @Published
     /// selected `ProjectFile.id`s

--- a/CavernSeer/Models/SavedProjectModel.swift
+++ b/CavernSeer/Models/SavedProjectModel.swift
@@ -13,6 +13,7 @@ import Foundation
  */
 struct SavedProjectModel: Identifiable, Hashable, SavedStoredFileProtocol {
     typealias FileType = ProjectFile
+    typealias PreviewType = PreviewProjectModel
 
     /// the file basename, e.g. `proj_\(ISO8601-timestamp)`
     let id: String

--- a/CavernSeer/Models/SavedScanModel.swift
+++ b/CavernSeer/Models/SavedScanModel.swift
@@ -13,8 +13,9 @@ import Foundation
  */
 struct SavedScanModel: Identifiable, Hashable, SavedStoredFileProtocol {
     typealias FileType = ScanFile
+    typealias PreviewType = PreviewScanModel
 
-    /// the file basename, e.g. `scan_\(ISO8601-timestamp)`
+    /// the file name, e.g. `scan_\(ISO8601-timestamp).\(FileType.fileExtension)`
     let id: String
     /// the URL the file was read from
     let url: URL

--- a/CavernSeer/Models/Serializations/ScanFile.swift
+++ b/CavernSeer/Models/Serializations/ScanFile.swift
@@ -42,6 +42,7 @@ final class ScanFile : NSObject, NSSecureCoding, StoredFileProtocol {
         lines: [SurveyLineEntity]
     ) {
         self.init(
+            name: name,
             timestamp: date ?? Date(),
             center: map.center,
             extent: map.extent,

--- a/CavernSeer/Models/StoreProtocol.swift
+++ b/CavernSeer/Models/StoreProtocol.swift
@@ -37,7 +37,7 @@ extension StoreProtocol {
      *  otherwise throws from the `ModelType` constructor.
      */
     func getModel(url: URL) throws -> ModelType {
-        if let model = cachedModelData.first(where: { $0.getURL() == url }) {
+        if let model = cachedModelData.first(where: { $0.url == url }) {
             return model
         }
 
@@ -76,8 +76,8 @@ extension StoreProtocol {
     func update() throws {
         let newURLs = getDirectoryURLs()
 
-        let alreadyPreviewedURLs = previews.map { preview in preview.getURL() }
-        let alreadyCachedURLs = cachedModelData.map { model in model.getURL() }
+        let alreadyPreviewedURLs = previews.map { preview in preview.url }
+        let alreadyCachedURLs = cachedModelData.map { model in model.url }
 
         let indicesToRemove = IndexSet(
             alreadyCachedURLs.indices.filter {
@@ -105,7 +105,7 @@ extension StoreProtocol {
         let modelIndex = cachedModelData.firstIndex { $0.id == id }
 
         if previewIndex != nil {
-            let url = previews[previewIndex!].getURL()
+            let url = previews[previewIndex!].url
             do {
                 try fileManager.removeItem(at: url)
             } catch {

--- a/CavernSeer/Models/StoreProtocol.swift
+++ b/CavernSeer/Models/StoreProtocol.swift
@@ -8,23 +8,8 @@
 
 import Foundation
 
-protocol StoredFileProtocol : NSObject, NSSecureCoding {
-    static var fileExtension: String { get }
-    func getTimestamp() -> Date
-}
-
-protocol SavedStoredFileProtocol {
-    associatedtype FileType: StoredFileProtocol
-
-    var id: String { get }
-    init(url: URL) throws
-    func getURL() -> URL
-    func getFile() -> FileType
-}
-
 protocol StoreProtocol : ObservableObject {
     associatedtype ModelType: SavedStoredFileProtocol
-    // associatedtype FileType: StoredFileProtocol
     associatedtype FileType: StoredFileProtocol = ModelType.FileType
 
     var directoryName: String { get }

--- a/CavernSeer/Models/StoreProtocol.swift
+++ b/CavernSeer/Models/StoreProtocol.swift
@@ -30,6 +30,8 @@ protocol StoreProtocol : ObservableObject {
 
 extension StoreProtocol {
 
+    static var MaxCachedModels: Int { 2 }
+
     /**
      * Try to get a model from a baseName; first try the cache, then try the file
      *  otherwise throws from the `ModelType` constructor.
@@ -40,7 +42,13 @@ extension StoreProtocol {
         }
 
         let model = try ModelType(url: url)
-//        cachedModelData.append(model)
+
+        let cacheToRemove = cachedModelData.count - Self.MaxCachedModels + 1
+        if cacheToRemove > 0 {
+            cachedModelData.removeFirst(cacheToRemove)
+        }
+        cachedModelData.append(model)
+
         return model
     }
 

--- a/CavernSeer/Models/StoreProtocol.swift
+++ b/CavernSeer/Models/StoreProtocol.swift
@@ -11,6 +11,8 @@ import Foundation
 protocol StoreProtocol : ObservableObject {
     associatedtype ModelType: SavedStoredFileProtocol
     associatedtype FileType: StoredFileProtocol = ModelType.FileType
+    associatedtype PreviewType: PreviewStoredFileProtocol
+        = ModelType.PreviewType
 
     var directoryName: String { get }
     var filePrefix: String { get }
@@ -20,11 +22,27 @@ protocol StoreProtocol : ObservableObject {
     var fileManager: FileManager { get }
     var dateFormatter: ISO8601DateFormatter { get }
 
-    var modelData: [ModelType] { get set }
+    var cachedModelData: [ModelType] { get set }
+
+    var previews: [PreviewType] { get set }
 }
 
 
 extension StoreProtocol {
+
+    /**
+     * Try to get a model from a baseName; first try the cache, then try the file
+     *  otherwise throws from the `ModelType` constructor.
+     */
+    func getModel(url: URL) throws -> ModelType {
+        if let model = cachedModelData.first(where: { $0.getURL() == url }) {
+            return model
+        }
+
+        let model = try ModelType(url: url)
+//        cachedModelData.append(model)
+        return model
+    }
 
     /**
      * Save a file to the store directory.
@@ -44,41 +62,59 @@ extension StoreProtocol {
         return newSaveUrl
     }
 
-    func update(urls: [URL]? = nil) throws {
-        let newURLs = urls ?? getDirectoryURLs()
+    /**
+     * Update the `previews` and `cachedModelData` based on the files in `directory`.
+     */
+    func update() throws {
+        let newURLs = getDirectoryURLs()
 
-        let cachedURLs = modelData.map { model in model.getURL() }
+        let alreadyPreviewedURLs = previews.map { preview in preview.getURL() }
+        let alreadyCachedURLs = cachedModelData.map { model in model.getURL() }
 
-        let difference = newURLs.difference(from: cachedURLs)
+        let indicesToRemove = IndexSet(
+            alreadyCachedURLs.indices.filter {
+                (index: Int) -> Bool in
+                let url = alreadyCachedURLs[index]
+                return  !newURLs.contains(url)
+            }
+        )
+        cachedModelData.remove(atOffsets: indicesToRemove)
 
-        for change in difference {
+        // add or remove previews
+        for change in newURLs.difference(from: alreadyPreviewedURLs) {
             switch change {
                 case let .remove(offset, _, _):
-                    modelData.remove(at: offset)
+                    previews.remove(at: offset)
                 case let .insert(offset, url, _):
-                    let newDatum = try ModelType(url: url)
-                    modelData.insert(newDatum, at: offset)
+                    let newDatum = try PreviewType(url: url)
+                    previews.insert(newDatum, at: offset)
             }
         }
     }
 
-    func deleteFile(model: ModelType) {
-        let modelURL = model.getURL()
-        let index = modelData.firstIndex(where: { $0.getURL() == modelURL })
-        if index != nil {
+    func deleteFile(id: String) {
+        let previewIndex = previews.firstIndex { $0.id == id }
+        let modelIndex = cachedModelData.firstIndex { $0.id == id }
+
+        if previewIndex != nil {
+            let url = previews[previewIndex!].getURL()
             do {
-                try fileManager.removeItem(at: modelURL)
+                try fileManager.removeItem(at: url)
             } catch {
                 fatalError("Deletion failed: \(error.localizedDescription)")
             }
-            modelData.remove(at: index!)
+            previews.remove(at: previewIndex!)
         } else {
             fatalError("Model not found in modelData")
+        }
+
+        if modelIndex != nil {
+            cachedModelData.remove(at: modelIndex!)
         }
     }
 
     func importFile(model: ModelType) throws -> URL {
-        if modelData.contains(where: { $0.id == model.id }) {
+        if previews.contains(where: { $0.id == model.id }) {
             throw FileSaveError.AlreadyExists
         }
 
@@ -87,15 +123,14 @@ extension StoreProtocol {
     }
 
     internal func getSaveURL(file: FileType, baseName: String? = nil) -> URL {
-        var base: String? = baseName
-        if base == nil {
-            dateFormatter.timeZone = TimeZone.current
-            let dateString = dateFormatter.string(from: file.getTimestamp())
-            base = "\(filePrefix)_\(dateString)"
-        }
+        let base = baseName ?? file.name
 
+        return baseNameToURL(base: base)
+    }
+
+    internal func baseNameToURL(base: String) -> URL {
         return directory
-            .appendingPathComponent(base!)
+            .appendingPathComponent(base)
             .appendingPathExtension(fileExtension)
     }
 
@@ -141,4 +176,6 @@ extension StoreProtocol {
             fatalError("Could not resolve directory contents")
         }
     }
+
+
 }

--- a/CavernSeer/Tabs/ScanListTab/MakeProject/MakeProjectModel.swift
+++ b/CavernSeer/Tabs/ScanListTab/MakeProject/MakeProjectModel.swift
@@ -62,9 +62,7 @@ class MakeProjectModel : ObservableObject {
 
     convenience init(store: ScanStore, projectStore: ProjectStore) {
         self.init(
-            modelPool: store.modelData.filter {
-                store.selection.contains($0.id)
-            },
+            modelPool: store.getSelectionModels(),
             store,
             projectStore
         )

--- a/CavernSeer/Tabs/ScanListTab/SavedScanListView.swift
+++ b/CavernSeer/Tabs/ScanListTab/SavedScanListView.swift
@@ -21,15 +21,15 @@ struct SavedScanListView: View {
 
     var body: some View {
         List(selection: $scanStore.selection) {
-            ForEach(scanStore.modelData) {
-                model
+            ForEach(scanStore.previews) {
+                preview
                 in
                 NavigationLink(
-                    destination: SavedScanDetail(model: model),
-                    tag: model.id,
+                    destination: SavedScanDetail(url: preview.url),
+                    tag: preview.id,
                     selection: $scanStore.visibleScan
                 ) {
-                    SavedScanRow(model: model)
+                    SavedScanRow(preview: preview)
                 }
             }
             .onDelete(perform: delete)
@@ -54,10 +54,11 @@ struct SavedScanListView: View {
     }
 
     func delete(at offset: IndexSet) {
-        let modelData = scanStore.modelData
+        let previews = self.scanStore.previews
+
         offset
-            .map { modelData[$0] }
-            .forEach { self.scanStore.deleteFile(model: $0) }
+            .map { previews[$0] }
+            .forEach { self.scanStore.deleteFile(id: $0.id) }
     }
 }
 

--- a/CavernSeer/Tabs/ScanListTab/SavedScanRow.swift
+++ b/CavernSeer/Tabs/ScanListTab/SavedScanRow.swift
@@ -9,48 +9,49 @@
 import SwiftUI /// View
 
 struct SavedScanRow: View {
-    var model: SavedScanModel
+    var preview: PreviewScanModel
+
+    var image: Image?
 
     var body: some View {
         HStack {
-            self.showSnapshot(snapshot: model.scan.startSnapshot)
+            self.image
                 .map {
                     $0
                         .resizable()
                         .frame(width: 50, height: 50)
                 }
 
-            Text(model.id)
+            Text(preview.id)
 
             Spacer()
         }
     }
 
-    func showSnapshot(snapshot: SnapshotAnchor?) -> Image? {
+    init(preview: PreviewScanModel, image: Image? = nil) {
+        self.preview = preview
+        self.image = image ?? makeSnapshot(preview: preview)
+    }
+
+    private func makeSnapshot(preview: PreviewScanModel) -> Image? {
+
         guard
-            let imageData = snapshot?.imageData,
+            let imageData = preview.imageData,
             let uiImg = UIImage(data: imageData)
         else { return nil }
 
         return Image(uiImage: uiImg)
     }
+}
 
-//    func styleSnapshot(img: Image) -> some View {
-//        return img
-//            .resizable()
-//            .scaledToFill()
-//            .frame(height: 300)
+//#if DEBUG
+//struct SavedScanRow_Previews: PreviewProvider {
+//    static var previews: some View {
+//        Group {
+//            SavedScanRow(model: dummyData[0])
+//            SavedScanRow(model: dummyData[1])
+//        }
+//        .previewLayout(.fixed(width: 300, height: 70))
 //    }
-}
-
-#if DEBUG
-struct SavedScanRow_Previews: PreviewProvider {
-    static var previews: some View {
-        Group {
-            SavedScanRow(model: dummyData[0])
-            SavedScanRow(model: dummyData[1])
-        }
-        .previewLayout(.fixed(width: 300, height: 70))
-    }
-}
-#endif
+//}
+//#endif

--- a/CavernSeer/Tabs/ScanListTab/ScanListTabView.swift
+++ b/CavernSeer/Tabs/ScanListTab/ScanListTabView.swift
@@ -78,9 +78,9 @@ struct ScanListTabView: View {
         let ids = scanStore.selection
         scanStore.selection.removeAll()
 
-        scanStore.modelData
+        scanStore.previews
             .filter { ids.contains($0.id) }
-            .forEach { self.scanStore.deleteFile(model: $0) }
+            .forEach { self.scanStore.deleteFile(id: $0.id) }
 
         do {
             try scanStore.update()

--- a/CavernSeer/protocols/PreviewStoredFileProtocol.swift
+++ b/CavernSeer/protocols/PreviewStoredFileProtocol.swift
@@ -13,7 +13,7 @@ import Foundation
  */
 protocol PreviewStoredFileProtocol {
     var id: String { get }
+    var url: URL { get }
     var imageData: Data? { get }
     init(url: URL) throws
-    func getURL() -> URL
 }

--- a/CavernSeer/protocols/PreviewStoredFileProtocol.swift
+++ b/CavernSeer/protocols/PreviewStoredFileProtocol.swift
@@ -1,5 +1,5 @@
 //
-//  SavedStoredFileProtocol.swift
+//  PreviewStoredFileProtocol.swift
 //  CavernSeer
 //
 //  Created by Samuel Grush on 12/30/20.
@@ -8,12 +8,12 @@
 
 import Foundation
 
-protocol SavedStoredFileProtocol {
-    associatedtype FileType: StoredFileProtocol
-    associatedtype PreviewType: PreviewStoredFileProtocol
-
+/**
+ * A minimal representation of a `SavedStoredFileProtocol` implementation.
+ */
+protocol PreviewStoredFileProtocol {
     var id: String { get }
+    var imageData: Data? { get }
     init(url: URL) throws
     func getURL() -> URL
-    func getFile() -> FileType
 }

--- a/CavernSeer/protocols/SavedStoredFileProtocol.swift
+++ b/CavernSeer/protocols/SavedStoredFileProtocol.swift
@@ -13,7 +13,7 @@ protocol SavedStoredFileProtocol {
     associatedtype PreviewType: PreviewStoredFileProtocol
 
     var id: String { get }
+    var url: URL { get }
     init(url: URL) throws
-    func getURL() -> URL
     func getFile() -> FileType
 }

--- a/CavernSeer/protocols/SavedStoredFileProtocol.swift
+++ b/CavernSeer/protocols/SavedStoredFileProtocol.swift
@@ -1,0 +1,18 @@
+//
+//  SavedStoredFileProtocol.swift
+//  CavernSeer
+//
+//  Created by Samuel Grush on 12/30/20.
+//  Copyright © 2020 Samuel K. Grush. All rights reserved.
+//
+
+import Foundation
+
+protocol SavedStoredFileProtocol {
+    associatedtype FileType: StoredFileProtocol
+
+    var id: String { get }
+    init(url: URL) throws
+    func getURL() -> URL
+    func getFile() -> FileType
+}

--- a/CavernSeer/protocols/StoredFileProtocol.swift
+++ b/CavernSeer/protocols/StoredFileProtocol.swift
@@ -1,0 +1,14 @@
+//
+//  StoredFileProtocol.swift
+//  CavernSeer
+//
+//  Created by Samuel Grush on 12/30/20.
+//  Copyright © 2020 Samuel K. Grush. All rights reserved.
+//
+
+import Foundation
+
+protocol StoredFileProtocol : NSObject, NSSecureCoding {
+    static var fileExtension: String { get }
+    func getTimestamp() -> Date
+}

--- a/CavernSeer/protocols/StoredFileProtocol.swift
+++ b/CavernSeer/protocols/StoredFileProtocol.swift
@@ -11,4 +11,5 @@ import Foundation
 protocol StoredFileProtocol : NSObject, NSSecureCoding {
     static var fileExtension: String { get }
     func getTimestamp() -> Date
+    var name: String { get }
 }


### PR DESCRIPTION
Rather than storing ALL of the ScanFiles in memory, we now only hold up to two.

When filling the store, we still iterate over all of the files and open them fully to retrieve the name and snapshot, but only really need to do this once per file. This data is stored in a `PreviewStoredFileProtocol` which has enough info to show items in the list, and we only load the full file again once it's selected and all the info is needed.

Good enough improvement to resolve #9, but could definitely still use some work, e.g. using proper in-memory caching mechanisms to leave it up to the OS.

---

Oh and I commented out the Projects tab, since it's been delayed and won't be implemented until it's needed.