### PR TITLE
Finish distance unit conversion

### DIFF
--- a/CavernSeer.xcodeproj/project.pbxproj
+++ b/CavernSeer.xcodeproj/project.pbxproj
@@ -62,6 +62,8 @@
 		7E6C0EF324A838E200129E8C /* SavedScanModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E6C0EF224A838E200129E8C /* SavedScanModel.swift */; };
 		7E6C0EF524A9323900129E8C /* ARViewScannerContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E6C0EF424A9323900129E8C /* ARViewScannerContainer.swift */; };
 		7E6C0EF724A938ED00129E8C /* ScannerModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E6C0EF624A938ED00129E8C /* ScannerModel.swift */; };
+		7E7DEEE525AA24CE00320150 /* Float+round.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E7DEEE425AA24CE00320150 /* Float+round.swift */; };
+		7E7DEEEA25AA28F000320150 /* Double+round.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E7DEEE925AA28F000320150 /* Double+round.swift */; };
 		7E99F94F24B113290098D44B /* SurveyStation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E99F94E24B113290098D44B /* SurveyStation.swift */; };
 		7E99F95124B1134C0098D44B /* SurveyLineEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E99F95024B1134C0098D44B /* SurveyLineEntity.swift */; };
 		7E99F95324B1161E0098D44B /* SurveyLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E99F95224B1161E0098D44B /* SurveyLine.swift */; };
@@ -173,6 +175,8 @@
 		7E6C0EF224A838E200129E8C /* SavedScanModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SavedScanModel.swift; sourceTree = "<group>"; };
 		7E6C0EF424A9323900129E8C /* ARViewScannerContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ARViewScannerContainer.swift; sourceTree = "<group>"; };
 		7E6C0EF624A938ED00129E8C /* ScannerModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScannerModel.swift; sourceTree = "<group>"; };
+		7E7DEEE425AA24CE00320150 /* Float+round.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Float+round.swift"; sourceTree = "<group>"; };
+		7E7DEEE925AA28F000320150 /* Double+round.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Double+round.swift"; sourceTree = "<group>"; };
 		7E99F94E24B113290098D44B /* SurveyStation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyStation.swift; sourceTree = "<group>"; };
 		7E99F95024B1134C0098D44B /* SurveyLineEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyLineEntity.swift; sourceTree = "<group>"; };
 		7E99F95224B1161E0098D44B /* SurveyLine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyLine.swift; sourceTree = "<group>"; };
@@ -279,6 +283,8 @@
 				7E4003AD24AD5C7E00B709BD /* NSCoder+simd.swift */,
 				7EAE9CE82561FF5900EA66D0 /* UserDefaults+color.swift */,
 				7E43C631256B599600170C17 /* SCNInteractionMode+name.swift */,
+				7E7DEEE425AA24CE00320150 /* Float+round.swift */,
+				7E7DEEE925AA28F000320150 /* Double+round.swift */,
 			);
 			path = extensions;
 			sourceTree = "<group>";
@@ -704,6 +710,7 @@
 				7E9C2CE824B3FD4B00B9FC44 /* SavedScanDetail.swift in Sources */,
 				7E99F95324B1161E0098D44B /* SurveyLine.swift in Sources */,
 				7E43C620256B477900170C17 /* ColorsSettingsSection.swift in Sources */,
+				7E7DEEEA25AA28F000320150 /* Double+round.swift in Sources */,
 				7E0C5EFB24CE639E001C0D0E /* FileSaveError.swift in Sources */,
 				7E0C5EF624CE580B001C0D0E /* FileOpener.swift in Sources */,
 				7E23DB2A254E457000BABB52 /* ScaleBarModel.swift in Sources */,
@@ -728,6 +735,7 @@
 				7E0C5EF924CE5F0B001C0D0E /* FileOpenError.swift in Sources */,
 				7E6C0EED24A834E200129E8C /* SnapshotAnchor.swift in Sources */,
 				7E9CF3CC259D3D5F0036F6F7 /* PreviewStoredFileProtocol.swift in Sources */,
+				7E7DEEE525AA24CE00320150 /* Float+round.swift in Sources */,
 				7E9CF3DB259D5D140036F6F7 /* PreviewScanModel.swift in Sources */,
 				7E0C5EE524C90746001C0D0E /* ProjectStore.swift in Sources */,
 				7EAE9CCD2561B88600EA66D0 /* SettingsTabView.swift in Sources */,

--- a/CavernSeer/Models/LengthPreferenceEnum.swift
+++ b/CavernSeer/Models/LengthPreferenceEnum.swift
@@ -40,4 +40,12 @@ extension LengthPreference {
     {
         measure.converted(to: self.unit)
     }
+
+    func fromMetric(_ length: Double) -> Measurement<UnitLength> {
+        let metricLength = Measurement<UnitLength>(
+            value: length,
+            unit: .meters
+        )
+        return self.convert(metricLength)
+    }
 }

--- a/CavernSeer/Models/Serializations/ScanFile+Nodes.swift
+++ b/CavernSeer/Models/Serializations/ScanFile+Nodes.swift
@@ -9,7 +9,11 @@
 import ARKit /// UIColor, SCNNode, ARMeshGeometry, SCNGeometry, Data, simd_float4x4
 
 extension ScanFile {
-    func toSCNNodes(color: UIColor?, quilt: Bool) -> [SCNNode] {
+    func toSCNNodes(
+        color: UIColor?,
+        quilt: Bool,
+        lengthPref: LengthPreference
+    ) -> [SCNNode] {
         let meshAnchorNodes = self.meshAnchors.map {
             anchor in
             meshGeometryToNode(
@@ -33,7 +37,8 @@ extension ScanFile {
         let stationNodes = Array(stationDict.values)
 
         let lineNodes = self.lines.map {
-            line in line.toSCNNode(stationDict: stationDict)
+            line in
+            line.toSCNNode(stationDict: stationDict, lengthPref: lengthPref)
         }
 
         return meshAnchorNodes + lineNodes + stationNodes

--- a/CavernSeer/Models/Serializations/SurveyLine.swift
+++ b/CavernSeer/Models/Serializations/SurveyLine.swift
@@ -170,11 +170,8 @@ extension SurveyLine {
         _ endPos: simd_float3,
         lengthPref: LengthPreference
     ) -> String {
-        let metricDistance = Measurement<UnitLength>(
-            value: Double(simd_length(startPos - endPos)),
-            unit: .meters
-        )
-        var preferredDistance = lengthPref.convert(metricDistance)
+        let dist = Double(simd_length(startPos - endPos))
+        var preferredDistance = lengthPref.fromMetric(dist)
         preferredDistance.value = preferredDistance.value.roundedTo(places: 3)
         return preferredDistance.description
     }

--- a/CavernSeer/Models/SettingsStore.swift
+++ b/CavernSeer/Models/SettingsStore.swift
@@ -58,6 +58,12 @@ final class SettingsStore : NSObject, ObservableObject {
         }
     }
 
+    @Published
+    var formatter: NumberFormatter
+
+    @Published
+    var measureFormatter: MeasurementFormatter
+
     private func setValue<ValT:Equatable>(
         _ key: SettingsKey,
         from oldValue: ValT,
@@ -83,6 +89,8 @@ final class SettingsStore : NSObject, ObservableObject {
     override init() {
         /// register default values for our defaults
         def.register(defaults: getSettingsDefaultDictionary())
+
+        (self.formatter, self.measureFormatter) = Self.setupFormatters()
 
         super.init()
 
@@ -169,5 +177,24 @@ final class SettingsStore : NSObject, ObservableObject {
                     )
             }
         }
+    }
+
+    private static func setupFormatters()
+        -> (NumberFormatter, MeasurementFormatter)
+    {
+        let locale = NSLocale.current
+
+        let formatter = NumberFormatter()
+        formatter.locale = locale
+        formatter.allowsFloats = true
+        formatter.maximumFractionDigits = 5
+        formatter.usesGroupingSeparator = true
+        formatter.groupingSize = 3
+
+        let measurementFormatter = MeasurementFormatter()
+        measurementFormatter.numberFormatter = formatter
+        measurementFormatter.unitOptions = .providedUnit
+
+        return (formatter, measurementFormatter)
     }
 }

--- a/CavernSeer/Tabs/ScanListTab/Detail/Renders/ElevationCrossSectionRender.swift
+++ b/CavernSeer/Tabs/ScanListTab/Detail/Renders/ElevationCrossSectionRender.swift
@@ -207,6 +207,7 @@ struct ElevationCrossSectionRender: View {
     var color: UIColor?
     var ambientColor: Color?
     var quiltMesh: Bool
+    var unitsLength: LengthPreference
 
     @State
     private var doCrossSection = false
@@ -226,6 +227,7 @@ struct ElevationCrossSectionRender: View {
                 color: color,
                 ambientColor: ambientColor,
                 quiltMesh: quiltMesh,
+                unitsLength: unitsLength,
                 barSubview: barSubview,
                 depthOfField: depthOfField,
                 observer: drawOverlay
@@ -236,6 +238,7 @@ struct ElevationCrossSectionRender: View {
                 color: color,
                 ambientColor: ambientColor,
                 quiltMesh: quiltMesh,
+                unitsLength: unitsLength,
                 overlays: [drawOverlay],
                 showUI: false,
                 initialHeight: 20

--- a/CavernSeer/Tabs/ScanListTab/Detail/Renders/ElevationProjectedMiniWorldRender.swift
+++ b/CavernSeer/Tabs/ScanListTab/Detail/Renders/ElevationProjectedMiniWorldRender.swift
@@ -20,6 +20,7 @@ struct ElevationProjectedMiniWorldRender: View {
     var color: UIColor?
     var ambientColor: Color?
     var quiltMesh: Bool
+    var unitsLength: LengthPreference
 
     var barSubview: AnyView? = nil
 
@@ -38,7 +39,11 @@ struct ElevationProjectedMiniWorldRender: View {
     private var scaleBarModel = ScaleBarModel()
 
     private var sceneNodes: [SCNNode] {
-        return scan.toSCNNodes(color: color, quilt: quiltMesh)
+        return scan.toSCNNodes(
+            color: color,
+            quilt: quiltMesh,
+            lengthPref: unitsLength
+        )
     }
 
     private var offset: SCNVector3 {

--- a/CavernSeer/Tabs/ScanListTab/Detail/Renders/ElevationProjectedMiniWorldRender.swift
+++ b/CavernSeer/Tabs/ScanListTab/Detail/Renders/ElevationProjectedMiniWorldRender.swift
@@ -98,11 +98,11 @@ struct ElevationProjectedMiniWorldRender: View {
                     Spacer()
 
                     HStack {
-                        Button(action: { fly += 2 }) {
+                        Button(action: { fly += 1 }) {
                             Image(systemName: "arrow.up.square")
                         }
                         Text("depth")
-                        Button(action: { fly -= 2 }) {
+                        Button(action: { fly -= 1 }) {
                             Image(systemName: "arrow.down.square")
                         }
                     }

--- a/CavernSeer/Tabs/ScanListTab/Detail/Renders/MiniWorldRender.swift
+++ b/CavernSeer/Tabs/ScanListTab/Detail/Renders/MiniWorldRender.swift
@@ -11,20 +11,19 @@ import SceneKit /// SCN*
 
 struct MiniWorldRender: View {
 
-    @EnvironmentObject
-    var settings: SettingsStore
-
     var scan: ScanFile
 
     var color: UIColor?
     var ambientColor: Color?
     var quiltMesh: Bool
+    var unitsLength: LengthPreference
+    var interactionMode3d: SCNInteractionMode
 
     private var sceneNodes: [SCNNode] {
         return scan.toSCNNodes(
             color: color,
             quilt: quiltMesh,
-            lengthPref: settings.UnitsLength
+            lengthPref: unitsLength
         )
     }
 
@@ -40,7 +39,7 @@ struct MiniWorldRender: View {
         MiniWorldRenderController(
             sceneNodes: sceneNodes,
             snapshotModel: _snapshotModel,
-            interactionMode: $settings.InteractionMode3d,
+            interactionMode: interactionMode3d,
             ambientColor: ambientColor
         )
         .sheet(isPresented: $snapshotModel.showPrompt) {
@@ -59,18 +58,17 @@ final class MiniWorldRenderController :
     @ObservedObject
     var snapshotModel: SnapshotExportModel
 
-    @Binding
     var interactionMode: SCNInteractionMode
 
     init(
         sceneNodes: [SCNNode],
         snapshotModel: ObservedObject<SnapshotExportModel>,
-        interactionMode: Binding<SCNInteractionMode>,
+        interactionMode: SCNInteractionMode,
         ambientColor: Color?
     ) {
         self.sceneNodes = sceneNodes
         self._snapshotModel = snapshotModel
-        self._interactionMode = interactionMode
+        self.interactionMode = interactionMode
         self.ambientColor = ambientColor
         super.init(nibName: nil, bundle: nil)
     }

--- a/CavernSeer/Tabs/ScanListTab/Detail/Renders/MiniWorldRender.swift
+++ b/CavernSeer/Tabs/ScanListTab/Detail/Renders/MiniWorldRender.swift
@@ -21,7 +21,11 @@ struct MiniWorldRender: View {
     var quiltMesh: Bool
 
     private var sceneNodes: [SCNNode] {
-        return scan.toSCNNodes(color: color, quilt: quiltMesh)
+        return scan.toSCNNodes(
+            color: color,
+            quilt: quiltMesh,
+            lengthPref: settings.UnitsLength
+        )
     }
 
     var offset: SCNVector3 {

--- a/CavernSeer/Tabs/ScanListTab/Detail/Renders/PlanProjectedMiniWorldRender.swift
+++ b/CavernSeer/Tabs/ScanListTab/Detail/Renders/PlanProjectedMiniWorldRender.swift
@@ -16,6 +16,7 @@ struct PlanProjectedMiniWorldRender: View {
     var color: UIColor?
     var ambientColor: Color?
     var quiltMesh: Bool
+    var unitsLength: LengthPreference
 
     var selection: SurveyStation? = nil
 
@@ -32,7 +33,11 @@ struct PlanProjectedMiniWorldRender: View {
     private var scaleBarModel = ScaleBarModel()
 
     private var sceneNodes: [SCNNode] {
-        return scan.toSCNNodes(color: color, quilt: quiltMesh)
+        return scan.toSCNNodes(
+            color: color,
+            quilt: quiltMesh,
+            lengthPref: unitsLength
+        )
     }
 
     private var offset: SCNVector3 {

--- a/CavernSeer/Tabs/ScanListTab/Detail/Renders/PlanProjectedMiniWorldRender.swift
+++ b/CavernSeer/Tabs/ScanListTab/Detail/Renders/PlanProjectedMiniWorldRender.swift
@@ -66,7 +66,7 @@ struct PlanProjectedMiniWorldRender: View {
             )
             if self.showUI {
                 HStack {
-                    Stepper("Height: \(height)m", value: $height)
+                    Stepper(stepperLabel, value: $height)
                         .frame(maxWidth: 150)
                 }
             }
@@ -82,6 +82,17 @@ struct PlanProjectedMiniWorldRender: View {
         if (self.initialHeight != nil) {
             self.height = self.initialHeight!
         }
+    }
+
+    private var stepperLabel: String {
+        let metric = Measurement<UnitLength>(
+            value: Double(height),
+            unit: .meters
+        )
+        var preferred = unitsLength.convert(metric)
+        preferred.value = preferred.value.roundedTo(places: 1)
+
+        return "Height: \(preferred.description)"
     }
 }
 

--- a/CavernSeer/Tabs/ScanListTab/Detail/Renders/PlanProjectedMiniWorldRender.swift
+++ b/CavernSeer/Tabs/ScanListTab/Detail/Renders/PlanProjectedMiniWorldRender.swift
@@ -85,11 +85,7 @@ struct PlanProjectedMiniWorldRender: View {
     }
 
     private var stepperLabel: String {
-        let metric = Measurement<UnitLength>(
-            value: Double(height),
-            unit: .meters
-        )
-        var preferred = unitsLength.convert(metric)
+        var preferred = unitsLength.fromMetric(Double(height))
         preferred.value = preferred.value.roundedTo(places: 1)
 
         return "Height: \(preferred.description)"

--- a/CavernSeer/Tabs/ScanListTab/Detail/SavedScanDetailLinks.swift
+++ b/CavernSeer/Tabs/ScanListTab/Detail/SavedScanDetailLinks.swift
@@ -37,7 +37,9 @@ struct SavedScanDetailLinks: View {
                     scan: self.model.scan,
                     color: meshColor,
                     ambientColor: settings.ColorLightAmbient,
-                    quiltMesh: settings.ColorMeshQuilt
+                    quiltMesh: settings.ColorMeshQuilt,
+                    unitsLength: settings.UnitsLength,
+                    interactionMode3d: settings.InteractionMode3d
                 )
             ) {
                 HStack {

--- a/CavernSeer/Tabs/ScanListTab/Detail/SavedScanDetailLinks.swift
+++ b/CavernSeer/Tabs/ScanListTab/Detail/SavedScanDetailLinks.swift
@@ -26,7 +26,12 @@ struct SavedScanDetailLinks: View {
     var body: some View {
         List {
             NavigationLink(
-                destination: SavedScanDetailAdvanced(model: self.model)
+                destination: SavedScanDetailAdvanced(
+                    model: self.model,
+                    unitLength: settings.UnitsLength,
+                    formatter: settings.formatter,
+                    measureFormatter: settings.measureFormatter
+                )
             ) {
                 HStack {
                     Text("Advanced")

--- a/CavernSeer/Tabs/ScanListTab/Detail/SavedScanDetailLinks.swift
+++ b/CavernSeer/Tabs/ScanListTab/Detail/SavedScanDetailLinks.swift
@@ -49,7 +49,8 @@ struct SavedScanDetailLinks: View {
                     scan: self.model.scan,
                     color: meshColor,
                     ambientColor: settings.ColorLightAmbient,
-                    quiltMesh: settings.ColorMeshQuilt
+                    quiltMesh: settings.ColorMeshQuilt,
+                    unitsLength: settings.UnitsLength
                 )
             ) {
                 HStack {
@@ -61,7 +62,8 @@ struct SavedScanDetailLinks: View {
                     scan: self.model.scan,
                     color: meshColor,
                     ambientColor: settings.ColorLightAmbient,
-                    quiltMesh: settings.ColorMeshQuilt
+                    quiltMesh: settings.ColorMeshQuilt,
+                    unitsLength: settings.UnitsLength
                 )
             ) {
                 HStack {
@@ -73,7 +75,8 @@ struct SavedScanDetailLinks: View {
                 scan: self.model.scan,
                 color: meshColor,
                 ambientColor: settings.ColorLightAmbient,
-                quiltMesh: settings.ColorMeshQuilt
+                quiltMesh: settings.ColorMeshQuilt,
+                unitsLength: settings.UnitsLength
             )
             ) {
                 HStack {

--- a/CavernSeer/extensions/Double+round.swift
+++ b/CavernSeer/extensions/Double+round.swift
@@ -1,0 +1,18 @@
+//
+//  Double+round.swift
+//  CavernSeer
+//
+//  Created by Samuel Grush on 1/9/21.
+//  Copyright © 2021 Samuel K. Grush. All rights reserved.
+//
+
+import Foundation
+
+extension Double {
+    func roundedTo(places: Int) -> Double {
+        let adjuster = pow(10, Double(places))
+
+        let raisedValue = (self * adjuster).rounded()
+        return raisedValue / adjuster
+    }
+}

--- a/CavernSeer/extensions/Float+round.swift
+++ b/CavernSeer/extensions/Float+round.swift
@@ -1,0 +1,19 @@
+//
+//  Float+round.swift
+//  CavernSeer
+//
+//  Created by Samuel Grush on 1/9/21.
+//  Copyright © 2021 Samuel K. Grush. All rights reserved.
+//
+
+import Foundation
+
+extension Float {
+    func roundedTo(places: Int) -> Float {
+        let adjuster = pow(10, Float(places))
+
+        let raisedValue = (self * adjuster).rounded()
+        return raisedValue / adjuster
+    }
+}
+


### PR DESCRIPTION
This PR adds more functionality for handling `LengthPreference` in all length related areas (all are unit-converted).
Additionally:
 * adds some handling for formatting of non-length numbers in other areas.
 * SurveyLine text billboarding now always faces the camera.
 * SettingsStore provides a NumberFormatter and a MeasurementFormatter which share formatting configurations.
 * cuts the forward/backward depth jump distance from 2m to 1m
 * reformatted SavedScanDetailsAdvanced view

