### PR TITLE
Support running in simulator

### DIFF
--- a/CavernSeer/ContentView.swift
+++ b/CavernSeer/ContentView.swift
@@ -8,17 +8,19 @@
 
 import SwiftUI
 
+fileprivate let supportedTabs: [TabProtocol] = [
+    ProjectListTab(),
+    ScanListTab(),
+    ScannerTab(),
+    SettingsTab(),
+].filter({ $0.isSupported })
+
 struct ContentView: View {
     @State private var selection: Tabs = Tabs.ScanListTab
     @EnvironmentObject var scanStore: ScanStore
     @EnvironmentObject var fileOpener: FileOpener
 
-    let tabs: [TabProtocol] = [
-//        ProjectListTab(),
-        ScanListTab(),
-        ScannerTab(),
-        SettingsTab(),
-    ]
+    let tabs: [TabProtocol] = supportedTabs
  
     var body: some View {
         TabView(selection: $selection){

--- a/CavernSeer/Tabs/ProjectListTab/ProjectListTabView.swift
+++ b/CavernSeer/Tabs/ProjectListTab/ProjectListTabView.swift
@@ -9,6 +9,9 @@
 import SwiftUI
 
 final class ProjectListTab : TabProtocol {
+    /// `false` as this is incomplete
+    let isSupported: Bool = false
+
     var tab = Tabs.ProjectListTab
     var tabName = "Project List"
     var tabImage: Image { Image(systemName: "list.bullet.indent") }

--- a/CavernSeer/Tabs/ScanListTab/ScanListTabView.swift
+++ b/CavernSeer/Tabs/ScanListTab/ScanListTabView.swift
@@ -10,6 +10,8 @@ import SwiftUI /// View, Image
 
 final class ScanListTab : TabProtocol {
 
+    let isSupported = true
+
     var tab: Tabs = Tabs.ScanListTab
     var tabName = "Scan List"
     var tabImage: Image { Image(systemName: "list.dash") }

--- a/CavernSeer/Tabs/ScannerTab/Models/ScannerModel.swift
+++ b/CavernSeer/Tabs/ScannerTab/Models/ScannerModel.swift
@@ -96,7 +96,9 @@ final class ScannerModel: UIGestureRecognizer, ObservableObject {
 
         self.drawView?.removeFromSuperview()
 
+        #if !targetEnvironment(simulator)
         self.arView?.session.delegate = nil
+        #endif
         self.arView?.scene.anchors.removeAll()
         self.arView = nil
         self.drawView = nil
@@ -127,6 +129,7 @@ final class ScannerModel: UIGestureRecognizer, ObservableObject {
 
     /// stop the scan and export all data to a `ScanFile`
     func showMesh(_ show: Bool) {
+        #if !targetEnvironment(simulator)
         if show {
             arView?.debugOptions.insert(.showSceneUnderstanding)
             arView?.debugOptions.insert(.showWorldOrigin)
@@ -134,6 +137,7 @@ final class ScannerModel: UIGestureRecognizer, ObservableObject {
             arView?.debugOptions.remove(.showSceneUnderstanding)
             arView?.debugOptions.remove(.showWorldOrigin)
         }
+        #endif
     }
 
     func saveScan(scanStore: ScanStore) {
@@ -147,6 +151,7 @@ final class ScannerModel: UIGestureRecognizer, ObservableObject {
 
         let date = Date()
 
+        #if !targetEnvironment(simulator)
         arView.session.getCurrentWorldMap { [weak self] worldMap, error in
 
             guard let self = self else { return }
@@ -186,14 +191,19 @@ final class ScannerModel: UIGestureRecognizer, ObservableObject {
 
             self.scanEnabled = false
         }
+        #endif
     }
 
     private func pause() {
+        #if !targetEnvironment(simulator)
         arView?.session.pause()
+        #endif
     }
 
     private func unpause() {
+        #if !targetEnvironment(simulator)
         arView?.session.run(arView!.session.configuration!)
+        #endif
     }
 
     /// Start a new scan with `scanConfiguration`
@@ -212,6 +222,8 @@ final class ScannerModel: UIGestureRecognizer, ObservableObject {
 
         showMesh(true)
 
+        #if !targetEnvironment(simulator)
+
         arView.environment.sceneUnderstanding.options = [
             .occlusion
         ]
@@ -224,6 +236,8 @@ final class ScannerModel: UIGestureRecognizer, ObservableObject {
                 .resetTracking
             ]
         )
+
+        #endif
 
         startSnapshot = SnapshotAnchor(capturing: arView, suffix: "start")
 
@@ -241,6 +255,8 @@ final class ScannerModel: UIGestureRecognizer, ObservableObject {
 
         showMesh(false)
 
+        #if !targetEnvironment(simulator)
+
         arView.environment.sceneUnderstanding.options = []
         let clearingOptions: ARSession.RunOptions = [
             .resetSceneReconstruction,
@@ -252,13 +268,16 @@ final class ScannerModel: UIGestureRecognizer, ObservableObject {
             arView.session.run(currentConfig, options: clearingOptions)
         }
 
+        #endif
+
         arView.scene.anchors.removeAll()
         surveyStations.removeAll()
         surveyLines.drawables.removeAll()
         drawView.setNeedsDisplay()
 
+        #if !targetEnvironment(simulator)
         arView.session.run(passiveConfiguration, options: clearingOptions)
-
+        #endif
     }
 
     private func setupPassiveConfig() {
@@ -273,6 +292,7 @@ final class ScannerModel: UIGestureRecognizer, ObservableObject {
     }
 
     private func setupARView(arView: ARView) {
+        #if !targetEnvironment(simulator)
         arView.automaticallyConfigureSession = false
         arView.renderOptions = [
             .disablePersonOcclusion,
@@ -280,6 +300,7 @@ final class ScannerModel: UIGestureRecognizer, ObservableObject {
             .disableHDR,
             .disableMotionBlur,
         ]
+        #endif
     }
 
     private func setupDrawView(drawView: DrawOverlay, arView: ARView) {
@@ -357,6 +378,7 @@ extension ScannerModel {
     }
 
     private func tappedOnNonentity(tapLoc: CGPoint) {
+        #if !targetEnvironment(simulator)
         guard
             let arView = self.arView,
             let surveyLines = self.surveyLines,
@@ -381,5 +403,6 @@ extension ScannerModel {
             surveyLines.drawables.append(line)
             line.updateProjections(arView: arView)
         }
+        #endif
     }
 }

--- a/CavernSeer/Tabs/ScannerTab/ScannerTabView.swift
+++ b/CavernSeer/Tabs/ScannerTab/ScannerTabView.swift
@@ -9,6 +9,8 @@
 import SwiftUI /// AnyView, View, Image, EnvironmentObject
 
 final class ScannerTab : TabProtocol {
+    var isSupported: Bool { ScannerModel.supportsScan }
+
     var tab: Tabs = Tabs.ScanTab
     var tabName = "Scanner"
     var tabImage: Image { Image(systemName: "camera.viewfinder") }

--- a/CavernSeer/Tabs/SettingsTab/SettingsTabView.swift
+++ b/CavernSeer/Tabs/SettingsTab/SettingsTabView.swift
@@ -9,6 +9,8 @@
 import SwiftUI
 
 final class SettingsTab : TabProtocol {
+    let isSupported: Bool = true
+    
     var tab: Tabs = .SettingsTab
     var tabName = "Settings"
     var tabImage: Image { Image(systemName: "gear") }

--- a/CavernSeer/Tabs/TabProtocol.swift
+++ b/CavernSeer/Tabs/TabProtocol.swift
@@ -11,6 +11,8 @@ import SwiftUI /// Image, AnyView
 
 protocol TabProtocol {
 
+    var isSupported: Bool { get }
+
     var tab: Tabs { get }
     var tabName: String { get }
     var tabImage: Image { get }


### PR DESCRIPTION
Added simulator support by omitting `ScannerModel` code when targeting simulators.
Also hide unsupported tabs to reduce confusion on unsupported platforms.

<img src="https://user-images.githubusercontent.com/21208885/104270983-5a631000-545f-11eb-8a87-de2ea58b653e.png" width="200">
