### PR TITLE
Scanner UI improvements

### DIFF
--- a/CavernSeer/ContentView.swift
+++ b/CavernSeer/ContentView.swift
@@ -99,7 +99,15 @@ struct ContentView: View {
 }
 
 struct ContentView_Previews: PreviewProvider {
+
     static var previews: some View {
+
+        let scanStore = ScanStore()
+        let projStore = ProjectStore()
+        let fileOpener = FileOpener(scanStore, projStore)
+
         ContentView()
+            .environmentObject(scanStore)
+            .environmentObject(fileOpener)
     }
 }

--- a/CavernSeer/Models/PreviewScanModel.swift
+++ b/CavernSeer/Models/PreviewScanModel.swift
@@ -7,6 +7,9 @@
 //
 
 import Foundation
+#if DEBUG
+import UIKit
+#endif
 
 struct PreviewScanModel: Identifiable, Hashable, PreviewStoredFileProtocol {
 
@@ -34,4 +37,15 @@ struct PreviewScanModel: Identifiable, Hashable, PreviewStoredFileProtocol {
         self.name = scan.name
         self.imageData = scan.startSnapshot?.imageData
     }
+
+    #if DEBUG
+    // Debug Initializer
+    init(id: String, sysImage: String = "arkit") {
+        self.id = id
+        self.url = URL(string: "debug://\(id)")!
+        self.name = "NameFrom:\(id)"
+        self.fileSize = 0
+        self.imageData = UIImage(systemName: sysImage)?.pngData()
+    }
+    #endif
 }

--- a/CavernSeer/Models/ScanStore.swift
+++ b/CavernSeer/Models/ScanStore.swift
@@ -61,10 +61,16 @@ final class ScanStore : StoreProtocol {
 
 #if DEBUG
 
-let dummyData: [SavedScanModel] = [
-    SavedScanModel(id: "hat.arscanfile"),
-    SavedScanModel(id: "bat.arscanfile"),
-    SavedScanModel(id: "tat.arscanfile"),
+let dummySavedScans: [SavedScanModel] = [
+    .init(id: "hat.arscanfile"),
+    .init(id: "bat.arscanfile"),
+    .init(id: "tat.arscanfile"),
+]
+
+let dummyPreviewScans: [PreviewScanModel] = [
+    .init(id: "hat.arscanfile"),
+    .init(id: "bat.arscanfile"),
+    .init(id: "tat.arscanfile"),
 ]
 
 #endif

--- a/CavernSeer/Tabs/ScanListTab/Detail/SavedScanDetailAdvanced.swift
+++ b/CavernSeer/Tabs/ScanListTab/Detail/SavedScanDetailAdvanced.swift
@@ -151,7 +151,7 @@ struct MeshAnchorDetail: View {
 struct SavedScanDetailAdvanced_Previews: PreviewProvider {
     static var previews: some View {
         SavedScanDetailAdvanced(
-            model: dummyData[1],
+            model: dummySavedScans[1],
             unitLength: .MetricMeter,
             formatter: NumberFormatter(),
             measureFormatter: MeasurementFormatter()

--- a/CavernSeer/Tabs/ScanListTab/ScanListTabView.swift
+++ b/CavernSeer/Tabs/ScanListTab/ScanListTabView.swift
@@ -38,8 +38,32 @@ struct ScanListTabView: View {
 
 #if DEBUG
 struct ScanListTabView_Previews: PreviewProvider {
+
+    private static let scanStore = setupScanStore()
+
     static var previews: some View {
         ScanListTabView()
+            .environmentObject(scanStore)
+
+        Group {
+            ScanListTabView()
+                .previewDevice(PreviewDevice(rawValue: "iPhone 12 Pro"))
+                .environment(\.colorScheme, .dark)
+
+            ScanListTabView()
+                .previewDevice(PreviewDevice(rawValue: "iPad Pro (11-inch)"))
+                .environment(\.colorScheme, .light)
+
+        }.environmentObject(scanStore)
+    }
+
+    private static func setupScanStore() -> ScanStore {
+        let store = ScanStore()
+
+        store.cachedModelData = dummySavedScans
+        store.previews = dummyPreviewScans
+
+        return store
     }
 }
 #endif

--- a/CavernSeer/Tabs/ScannerTab/ARViewScannerContainer.swift
+++ b/CavernSeer/Tabs/ScannerTab/ARViewScannerContainer.swift
@@ -14,6 +14,7 @@ struct ARViewScannerContainer: UIViewRepresentable {
 
     func makeUIView(context: Context) -> ARView {
         let arView = ARView(frame: .zero)
+        arView.backgroundColor = UIColor.systemBackground
 
         scanModel?.onViewAppear(arView: arView)
         return arView

--- a/CavernSeer/Tabs/ScannerTab/ScannerTabView.swift
+++ b/CavernSeer/Tabs/ScannerTab/ScannerTabView.swift
@@ -22,54 +22,126 @@ final class ScannerTab : TabProtocol {
 
 struct ScannerTabView: View {
 
-    @EnvironmentObject
-    var scanStore: ScanStore
-
-    @ObservedObject
-    var scanModel = ScannerModel()
-
     var isSelected: Bool
 
-    var body: some View {
-        VStack {
+    @EnvironmentObject
+    private var scanStore: ScanStore
 
+    @ObservedObject
+    private var scanModel = ScannerModel()
+
+    var body: some View {
+        ZStack(alignment: .bottom) {
             if isSelected {
                 ARViewScannerContainer(scanModel: scanModel)
                     .edgesIgnoringSafeArea(.all)
             }
 
+            controls
+        }
+    }
+
+    private var controls: some View {
+        VStack {
             HStack {
-                HStack {
-                    Button(action: {
-                        self.scanModel.scanEnabled = true
-                    }) {
-                        Text("Start Scan")
-                    }.disabled(scanModel.scanEnabled)
+                Text(scanModel.message)
+            }
 
-                    Button(action: {
-                        self.scanModel.scanEnabled = false
-                    }) {
-                        Text("Cancel Scan")
-                    }.disabled(!scanModel.scanEnabled)
+            // controls
+            HStack {
+                debugButtons.frame(width: 100)
 
-                    Button(action: {
-                        self.scanModel.saveScan(scanStore: self.scanStore)
-                    }) {
-                        Text("Save")
-                    }.disabled(!scanModel.scanEnabled)
-                }
+                Spacer()
 
-                HStack {
-                    Toggle("Debug", isOn: $scanModel.showDebug)
-                        .frame(maxWidth: 100)
+                if scanModel.scanEnabled {
+                    saveOrCancel
+                } else {
+                    captureButton
                 }
 
                 Spacer()
 
-                HStack {
-                    Text(scanModel.message)
-                }
+                flashButton.frame(width: 100)
             }
+            .padding(10)
+        }
+    }
+
+    private var captureButton: some View {
+
+        let color: Color = .primary
+
+        /// the standard start-capture button
+        return Button(
+            action: { self.scanModel.scanEnabled = true },
+            label: {
+                Circle()
+                    .foregroundColor(color)
+                    .frame(width: 70, height: 70, alignment: .center)
+                    .overlay(
+                        Circle()
+                            .stroke(color, lineWidth: 2)
+                            .frame(width: 80, height: 80, alignment: .center)
+                    )
+            }
+        )
+
+    }
+
+    private var saveOrCancel: some View {
+        ZStack(alignment: .topTrailing) {
+            /// save-capture button
+            Button(
+                action: { self.scanModel.saveScan(scanStore: self.scanStore) },
+                label: {
+                    Circle()
+                        .foregroundColor(.secondary)
+                        .frame(width: 70, height: 70, alignment: .center)
+                }
+            )
+            /// cancel button
+            Button(
+                action: { self.scanModel.scanEnabled = false },
+                label: {
+                    Circle()
+                        .frame(width: 20, height: 20, alignment: .center)
+                        .overlay(
+                            Image(systemName: "trash")
+                                .font(.system(size: 20, weight: .medium, design: .default))
+                                .foregroundColor(.red)
+                        )
+                }
+            )
+        }
+    }
+
+    private var flashButton: some View {
+        let enabled = self.scanModel.torchEnabled
+
+        return Button(
+            action: { self.scanModel.torchEnabled = !enabled },
+            label: {
+                Image(systemName: enabled ? "bolt.fill" : "bolt.slash.fill")
+                    .font(.system(size: 20, weight: .medium, design: .default))
+            }
+        )
+        .accentColor(enabled ? .yellow : .white)
+    }
+
+    private var debugButtons: some View {
+        let debug = self.scanModel.showDebug
+        let mesh = self.scanModel.meshEnabled
+
+        return VStack {
+            Button(
+                action: { self.scanModel.showDebug = !debug },
+                label: { Text("Debug").accentColor(debug ? .primary : .secondary) }
+            )
+            .padding(.bottom, 5)
+            Button(
+                action: { self.scanModel.meshEnabled = !mesh },
+                label: { Text("Mesh").accentColor(mesh ? .primary : .secondary) }
+            )
         }
     }
 }

--- a/CavernSeer/Tabs/ScannerTab/ScannerTabView.swift
+++ b/CavernSeer/Tabs/ScannerTab/ScannerTabView.swift
@@ -27,6 +27,9 @@ struct ScannerTabView: View {
     @EnvironmentObject
     private var scanStore: ScanStore
 
+    @Environment(\.fakeScan)
+    private var fakeScan: Bool
+
     @ObservedObject
     private var scanModel = ScannerModel()
 
@@ -44,6 +47,10 @@ struct ScannerTabView: View {
         }
     }
 
+    private var scanEnabled: Bool {
+        return self.scanModel.scanEnabled || self.fakeScan
+    }
+
     private var controls: some View {
         VStack {
             HStack {
@@ -56,7 +63,7 @@ struct ScannerTabView: View {
 
                 Spacer()
 
-                if scanModel.scanEnabled {
+                if scanEnabled {
                     saveOrCancel
                 } else {
                     captureButton
@@ -163,6 +170,7 @@ struct ScannerTabView_Previews: PreviewProvider {
             view
                 .previewDevice(PreviewDevice(rawValue: "iPhone 12 Pro"))
                 .environment(\.colorScheme, .dark)
+                .environment(\.fakeScan, true)
 
             view
                 .previewDevice(PreviewDevice(rawValue: "iPad Pro (11-inch)"))
@@ -185,3 +193,18 @@ struct ScannerTabView_Previews: PreviewProvider {
 }
 
 #endif
+
+fileprivate struct FakeScanEnvironmentKey: EnvironmentKey {
+    static let defaultValue: Bool = false
+}
+
+fileprivate extension EnvironmentValues {
+    var fakeScan: Bool {
+        get {
+            return self[FakeScanEnvironmentKey]
+        }
+        set {
+            self[FakeScanEnvironmentKey] = newValue
+        }
+    }
+}

--- a/CavernSeer/Tabs/ScannerTab/ScannerTabView.swift
+++ b/CavernSeer/Tabs/ScannerTab/ScannerTabView.swift
@@ -38,6 +38,9 @@ struct ScannerTabView: View {
             }
 
             controls
+                .background(
+                    Color(UIColor.systemGray6).opacity(0.4).ignoresSafeArea()
+                )
         }
     }
 

--- a/CavernSeer/Tabs/ScannerTab/ScannerTabView.swift
+++ b/CavernSeer/Tabs/ScannerTab/ScannerTabView.swift
@@ -55,8 +55,10 @@ struct ScannerTabView: View {
 
     private var controls: some View {
         VStack {
-            HStack {
-                Text(scanModel.message)
+            if !self.scanModel.message.isEmpty {
+                HStack {
+                    Text(scanModel.message)
+                }
             }
 
             // controls
@@ -105,7 +107,17 @@ struct ScannerTabView: View {
     }
 
     private var saveOrCancel: some View {
-        ZStack(alignment: .topTrailing) {
+        VStack(alignment: .center) {
+            /// cancel button
+            Button(
+                action: { self.scanModel.scanEnabled = false },
+                label: {
+                    Text("Cancel Scan")
+                        .foregroundColor(.red)
+                        .padding(5)
+                }
+            )
+
             /// save-capture button
             Button(
                 action: { self.scanModel.saveScan(scanStore: self.scanStore) },
@@ -113,19 +125,6 @@ struct ScannerTabView: View {
                     Circle()
                         .foregroundColor(.secondary)
                         .frame(width: 70, height: 70, alignment: .center)
-                }
-            )
-            /// cancel button
-            Button(
-                action: { self.scanModel.scanEnabled = false },
-                label: {
-                    Circle()
-                        .frame(width: 20, height: 20, alignment: .center)
-                        .overlay(
-                            Image(systemName: "trash")
-                                .font(.system(size: 20, weight: .medium, design: .default))
-                                .foregroundColor(.red)
-                        )
                 }
             )
         }

--- a/CavernSeer/Tabs/ScannerTab/ScannerTabView.swift
+++ b/CavernSeer/Tabs/ScannerTab/ScannerTabView.swift
@@ -22,6 +22,8 @@ final class ScannerTab : TabProtocol {
 
 struct ScannerTabView: View {
 
+    private let controlFrameHeight: CGFloat = 80
+
     var isSelected: Bool
 
     @EnvironmentObject
@@ -58,8 +60,8 @@ struct ScannerTabView: View {
             }
 
             // controls
-            HStack {
-                debugButtons.frame(width: 100)
+            HStack(alignment: .bottom) {
+                debugButtons.frame(width: 100, height: controlFrameHeight)
 
                 Spacer()
 
@@ -71,9 +73,13 @@ struct ScannerTabView: View {
 
                 Spacer()
 
-                flashButton.frame(width: 100)
+                if scanEnabled {
+                    flashButton.frame(width: 100, height: controlFrameHeight)
+                } else {
+                    Spacer().frame(width: 100, height: controlFrameHeight)
+                }
             }
-            .padding(10)
+            .padding(.init(top: 5, leading: 10, bottom: 20, trailing: 10))
         }
     }
 
@@ -133,9 +139,10 @@ struct ScannerTabView: View {
             label: {
                 Image(systemName: enabled ? "bolt.fill" : "bolt.slash.fill")
                     .font(.system(size: 20, weight: .medium, design: .default))
+                    .padding(10)
             }
         )
-        .accentColor(enabled ? .yellow : .white)
+        .accentColor(enabled ? .yellow : .primary)
     }
 
     private var debugButtons: some View {

--- a/CavernSeer/Tabs/ScannerTab/ScannerTabView.swift
+++ b/CavernSeer/Tabs/ScannerTab/ScannerTabView.swift
@@ -73,3 +73,40 @@ struct ScannerTabView: View {
         }
     }
 }
+
+
+#if DEBUG
+
+struct ScannerTabView_Previews: PreviewProvider {
+
+    private static let store = ScanStore()
+
+    private static let tab = ScannerTab()
+
+    static var previews: some View {
+        Group {
+            view
+                .previewDevice(PreviewDevice(rawValue: "iPhone 12 Pro"))
+                .environment(\.colorScheme, .dark)
+
+            view
+                .previewDevice(PreviewDevice(rawValue: "iPad Pro (11-inch)"))
+                .environment(\.colorScheme, .light)
+
+        }.environmentObject(store)
+    }
+
+    private static var view: some View {
+        TabView {
+            tab.getTabPanelView(selected: true)
+                .tabItem {
+                    VStack {
+                        tab.tabImage
+                        Text(tab.tabName)
+                    }
+                }
+        }
+    }
+}
+
+#endif


### PR DESCRIPTION
## UI
The primary improvement here was updating the scanner tab's UI.

This adds progress to #17 checkbox-1, but only partly as there are more user-experience improvements to come.

Old vs New:
<img src="https://user-images.githubusercontent.com/21208885/104956546-f5914380-5991-11eb-9785-78c098dde47e.PNG" width="300" />  <img src="https://user-images.githubusercontent.com/21208885/104956553-f9bd6100-5991-11eb-8318-7f9682a8029d.PNG" width="300" />

While the new version uses a good bit more space, that was intentional as I've been trying to follow Apple's UX guidelines (particularly in regards to layout) to make things more intuitive and less error-prone. 

## Additional changes

### PreviewProviders

I added PreviewProviders for the main `ContentView`, the `ScanListTabView`, and the `ScannerTabView` which necessitated changes to the `ScannerModel` to support the simulator.

### Functionality

In adding more room I was able to add an explicit option for toggling mesh visibility in the scan, and I suddenly realized that the onboard light could be used for aiding scanning! Beware, using the flash increases internal temperatures.