### PR TITLE
Fix file name outputs

### DIFF
--- a/CavernSeer/Models/ProjectStore.swift
+++ b/CavernSeer/Models/ProjectStore.swift
@@ -14,7 +14,7 @@ final class ProjectStore : StoreProtocol {
     typealias PreviewType = PreviewProjectModel
 
     let directoryName: String = "projects"
-    let filePrefix: String = "proj"
+    let filePrefix: String = FileType.filePrefix
     let fileExtension: String = FileType.fileExtension
     var directory: URL!
 

--- a/CavernSeer/Models/ScanStore.swift
+++ b/CavernSeer/Models/ScanStore.swift
@@ -14,7 +14,7 @@ final class ScanStore : StoreProtocol {
     typealias PreviewType = PreviewScanModel
 
     let directoryName: String = "scans"
-    let filePrefix: String = "scan"
+    let filePrefix: String = FileType.filePrefix
     let fileExtension: String = FileType.fileExtension
     var directory: URL!
 

--- a/CavernSeer/Models/Serializations/ProjectFile.swift
+++ b/CavernSeer/Models/Serializations/ProjectFile.swift
@@ -10,7 +10,8 @@ import Foundation
 import ARKit /// simd_float4x4
 
 final class ProjectFile : NSObject, StoredFileProtocol {
-    static var fileExtension: String = "cavernseerproj"
+    static let filePrefix = "proj"
+    static let fileExtension: String = "cavernseerproj"
 
     static let supportsSecureCoding: Bool = true
     static let currentEncodingVersion: Int32 = 1
@@ -58,8 +59,6 @@ final class ProjectFile : NSObject, StoredFileProtocol {
         coder.encode(name, forKey: PropertyKeys.name)
         coder.encode(scans as NSArray, forKey: PropertyKeys.scans)
     }
-
-    func getTimestamp() -> Date { timestamp }
 
     private struct PropertyKeys {
         static let version = "version"

--- a/CavernSeer/protocols/StoredFileProtocol.swift
+++ b/CavernSeer/protocols/StoredFileProtocol.swift
@@ -9,7 +9,27 @@
 import Foundation
 
 protocol StoredFileProtocol : NSObject, NSSecureCoding {
+    static var filePrefix: String { get }
     static var fileExtension: String { get }
-    func getTimestamp() -> Date
+    var timestamp: Date { get }
     var name: String { get }
+}
+
+extension StoredFileProtocol {
+    static func makeDefaultBaseName(
+        with date: Date,
+        as format: DateFormatter
+    ) -> String {
+        let datestr = format.string(from: date)
+        return "\(Self.filePrefix)_\(datestr)"
+    }
+
+    static func getDefaultDateFormatter(
+        tz: TimeZone = .current
+    ) -> DateFormatter {
+        let fmt = DateFormatter()
+        fmt.timeZone = tz
+        fmt.dateFormat = "yyyy-MM-dd'T'HHmmssZ"
+        return fmt
+    }
 }


### PR DESCRIPTION
Genericized stored file names to `\(prefix)_\(safe-date)`, e.g. `scan_2021-01-24T212100-0600`, which contains no illegal characters.