### PR TITLE
Memory safety catchups

### DIFF
--- a/CavernSeer.xcodeproj/xcshareddata/xcschemes/CavernSeer.xcscheme
+++ b/CavernSeer.xcodeproj/xcshareddata/xcschemes/CavernSeer.xcscheme
@@ -54,6 +54,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      enableASanStackUseAfterReturn = "YES"
+      disableMainThreadChecker = "YES"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
@@ -70,6 +72,23 @@
             ReferencedContainer = "container:CavernSeer.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <AdditionalOptions>
+         <AdditionalOption
+            key = "MallocStackLogging"
+            value = ""
+            isEnabled = "YES">
+         </AdditionalOption>
+         <AdditionalOption
+            key = "PrefersMallocStackLoggingLite"
+            value = ""
+            isEnabled = "YES">
+         </AdditionalOption>
+         <AdditionalOption
+            key = "MallocScribble"
+            value = ""
+            isEnabled = "YES">
+         </AdditionalOption>
+      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/CavernSeer/Tabs/ScanListTab/Detail/Renders/BaseProjectedMiniWorldRender.swift
+++ b/CavernSeer/Tabs/ScanListTab/Detail/Renders/BaseProjectedMiniWorldRender.swift
@@ -32,6 +32,10 @@ extension BaseProjectedMiniWorldRenderController {
     static var defaultColor: UIColor { .gray }
     static var selectedColor: UIColor { .blue }
 
+    static func dismantleUIView(_ uiView: SCNView, coordinator: Coordinator) {
+        uiView.overlaySKScene = nil
+    }
+
     func makeUIView(context: Context) -> SCNView {
         let sceneView = SCNView(frame: .zero)
         sceneView.backgroundColor = UIColor.systemBackground
@@ -82,9 +86,9 @@ extension BaseProjectedMiniWorldRenderController {
     ) {
         if self.showUI && self.scaleBarModel.scene.size.width == 0 {
             /// this really doesn't seem like the
-            DispatchQueue.main.async {
-                if let scn = renderer as? SCNView {
-
+            if let scn = renderer as? SCNView {
+                DispatchQueue.main.async {
+                    [unowned self] in
                     self.scaleBarModel.updateOverlay(bounds: scn.frame)
                 }
             }

--- a/CavernSeer/Tabs/ScanListTab/Detail/Renders/BaseProjectedMiniWorldRender.swift
+++ b/CavernSeer/Tabs/ScanListTab/Detail/Renders/BaseProjectedMiniWorldRender.swift
@@ -85,11 +85,11 @@ extension BaseProjectedMiniWorldRenderController {
         atTime time: TimeInterval
     ) {
         if self.showUI && self.scaleBarModel.scene.size.width == 0 {
-            /// this really doesn't seem like the
-            if let scn = renderer as? SCNView {
+            /// this really doesn't seem like the right solution...
+            if let scnFrame = (renderer as? SCNView)?.frame {
                 DispatchQueue.main.async {
-                    [unowned self] in
-                    self.scaleBarModel.updateOverlay(bounds: scn.frame)
+                    [weak self] in /// this self might've already closed out?
+                    self?.scaleBarModel.updateOverlay(bounds: scnFrame)
                 }
             }
         }

--- a/CavernSeer/Tabs/ScanListTab/Detail/Renders/ElevationCrossSectionRender.swift
+++ b/CavernSeer/Tabs/ScanListTab/Detail/Renders/ElevationCrossSectionRender.swift
@@ -47,7 +47,7 @@ fileprivate class CrossSectionPlanDrawOverlay :
      * The (parent) plan view updated.
      */
     override func parentUpdated(view: SCNView) {
-
+        self.parentView = view
     }
 
     /**
@@ -82,7 +82,7 @@ fileprivate class CrossSectionPlanDrawOverlay :
      * The (parent) plan view dismantled
      */
     override func parentDismantled(view: SCNView) {
-
+        self.removeFromSuperview()
     }
 
     func renderObserver(renderer: SCNSceneRenderer) {
@@ -152,7 +152,7 @@ fileprivate class CrossSectionPlanDrawOverlay :
             {
 
                 self.projectAndDrawLines(
-                    view: view,
+                    parentView: view,
                     ctx: context,
                     points: [
                         left,
@@ -183,12 +183,12 @@ fileprivate class CrossSectionPlanDrawOverlay :
      * Don't forget to line width and stroke color ahead of time!
      */
     private func projectAndDrawLines(
-        view: SCNView,
+        parentView: SCNView,
         ctx: CGContext,
         points: [SCNVector3]
     ) {
         let projectedPoints = points
-            .map { view.projectPoint($0) }
+            .map { parentView.projectPoint($0) }
             .map { CGPoint(x: Double($0.x), y: Double($0.y)) }
 
         ctx.beginPath()

--- a/CavernSeer/Tabs/ScanListTab/Detail/Renders/ElevationProjectedMiniWorldRender.swift
+++ b/CavernSeer/Tabs/ScanListTab/Detail/Renders/ElevationProjectedMiniWorldRender.swift
@@ -9,7 +9,7 @@
 import SwiftUI /// View
 import SceneKit /// SCN*
 
-protocol SCNRenderObserver {
+protocol SCNRenderObserver : AnyObject {
     func renderObserver(renderer: SCNSceneRenderer)
 }
 
@@ -61,12 +61,12 @@ struct ElevationProjectedMiniWorldRender: View {
                     rotation: $rotation,
                     depthOfField: depthOfField,
                     fly: $fly,
-                    renderModel: _renderModel,
-                    snapshotModel: _snapshotModel,
+                    renderModel: renderModel,
+                    snapshotModel: snapshotModel,
                     selection: selection,
-                    prevSelection: $prevSelection,
+                    prevSelection: prevSelection,
                     observer: observer,
-                    scaleBarModel: $scaleBarModel,
+                    scaleBarModel: scaleBarModel,
                     showUI: showUI
                 )
             }
@@ -105,10 +105,14 @@ struct ElevationProjectedMiniWorldRender: View {
             renderModel.doubleSidedButton()
         })
         .onAppear(perform: self.appeared)
+        .onDisappear(perform: self.disappeared)
     }
 
     private func appeared() {
         self.renderModel.updateScanAndSettings(scan: scan, settings: settings)
+    }
+    private func disappeared() {
+        self.renderModel.dismantle()
     }
 }
 
@@ -126,37 +130,33 @@ fileprivate final class ElevationProjectedMiniWorldRenderController :
     @Binding
     var fly: Int
     var selectedStation: SurveyStation?
-    @Binding
     var prevSelected: SurveyStation?
-    @Binding
-    var scaleBarModel: ScaleBarModel
-    @ObservedObject
-    var snapshotModel: SnapshotExportModel
-    @ObservedObject
-    var renderModel: GeneralRenderModel
-    var observer: SCNRenderObserver?
+    unowned var scaleBarModel: ScaleBarModel
+    unowned var snapshotModel: SnapshotExportModel
+    unowned var renderModel: GeneralRenderModel
+    unowned var observer: SCNRenderObserver?
 
     init(
         rotation: Binding<Int>,
         depthOfField: Double?,
         fly: Binding<Int>,
-        renderModel: ObservedObject<GeneralRenderModel>,
-        snapshotModel: ObservedObject<SnapshotExportModel>,
+        renderModel: GeneralRenderModel,
+        snapshotModel: SnapshotExportModel,
         selection: SurveyStation?,
-        prevSelection: Binding<SurveyStation?>,
+        prevSelection: SurveyStation?,
         observer: SCNRenderObserver?,
-        scaleBarModel: Binding<ScaleBarModel>,
+        scaleBarModel: ScaleBarModel,
         showUI: Bool
     ) {
         self.depthOfField = depthOfField
         self._rotation = rotation
         self._fly = fly
-        self._renderModel = renderModel
-        self._snapshotModel = snapshotModel
+        self.renderModel = renderModel
+        self.snapshotModel = snapshotModel
         self.selectedStation = selection
-        self._prevSelected = prevSelection
+        self.prevSelected = prevSelection
         self.observer = observer
-        self._scaleBarModel = scaleBarModel
+        self.scaleBarModel = scaleBarModel
         self.showUI = showUI
 
         super.init(nibName: nil, bundle: nil)

--- a/CavernSeer/Tabs/ScanListTab/Detail/Renders/ElevationProjectedMiniWorldRender.swift
+++ b/CavernSeer/Tabs/ScanListTab/Detail/Renders/ElevationProjectedMiniWorldRender.swift
@@ -101,11 +101,12 @@ struct ElevationProjectedMiniWorldRender: View {
         }
         .snapshotMenus(for: _snapshotModel)
         .navigationBarItems(trailing: HStack {
+            [unowned snapshotModel, unowned renderModel] in
             snapshotModel.promptButton(scan: scan)
             renderModel.doubleSidedButton()
         })
-        .onAppear(perform: self.appeared)
-        .onDisappear(perform: self.disappeared)
+        .onAppear(perform: { self.appeared() })
+        .onDisappear(perform: { self.disappeared() })
     }
 
     private func appeared() {

--- a/CavernSeer/Tabs/ScanListTab/Detail/Renders/ElevationProjectedMiniWorldRender.swift
+++ b/CavernSeer/Tabs/ScanListTab/Detail/Renders/ElevationProjectedMiniWorldRender.swift
@@ -105,8 +105,8 @@ struct ElevationProjectedMiniWorldRender: View {
             snapshotModel.promptButton(scan: scan)
             renderModel.doubleSidedButton()
         })
-        .onAppear(perform: { self.appeared() })
-        .onDisappear(perform: { self.disappeared() })
+        .onAppear(perform: self.appeared)
+        .onDisappear(perform: self.disappeared)
     }
 
     private func appeared() {

--- a/CavernSeer/Tabs/ScanListTab/Detail/Renders/GeneralRenderModel.swift
+++ b/CavernSeer/Tabs/ScanListTab/Detail/Renders/GeneralRenderModel.swift
@@ -23,7 +23,7 @@ class GeneralRenderModel : ObservableObject {
     public private(set) var shouldUpdateNodes = false
     public private(set) var initialUpdate = true
 
-    public private(set) var scan: ScanFile? = nil
+    public private(set) weak var scan: ScanFile? = nil
     public private(set) var offset: SCNVector3? = nil
 
     public private(set) var sceneNodes: [SCNNode] = []
@@ -37,10 +37,15 @@ class GeneralRenderModel : ObservableObject {
     public private(set) var interactionMode3d: SCNInteractionMode = .orbitAngleMapping
     public private(set) var lengthPref: LengthPreference = .CustomaryFoot
 
-    private var settings: SettingsStore? = nil
+    private weak var settings: SettingsStore? = nil
     private var settingsCancelBag = Set<AnyCancellable>()
 
     init() {
+    }
+
+    func dismantle() {
+        sceneNodes.removeAll()
+        settingsCancelBag.removeAll()
     }
 
     func viewUpdateHandler(scnView: SCNView) {
@@ -113,7 +118,8 @@ class GeneralRenderModel : ObservableObject {
         self.settingsCancelBag.removeAll()
         settings.$ColorMesh
             .sink {
-                let cgColor = $0?.cgColor
+                [unowned self] color in
+                let cgColor = color?.cgColor
                 self.color = (cgColor != nil && cgColor!.alpha > 0.05)
                     ? UIColor(cgColor: cgColor!)
                     : nil
@@ -123,26 +129,29 @@ class GeneralRenderModel : ObservableObject {
             .store(in: &settingsCancelBag)
         settings.$ColorLightAmbient
             .sink {
-                color in
+                [unowned self] color in
                 self.ambientColor = color.map { UIColor($0) }
                 self.updateColor()
             }
             .store(in: &settingsCancelBag)
         settings.$ColorMeshQuilt
             .sink {
-                self.quiltMesh = $0 ?? self.quiltMesh
+                [unowned self] doQuiltMesh in
+                self.quiltMesh = doQuiltMesh ?? self.quiltMesh
                 self.updateColor()
             }
             .store(in: &settingsCancelBag)
         settings.$InteractionMode3d
             .sink {
-                self.interactionMode3d = $0 ?? self.interactionMode3d
+                [unowned self] mode in
+                self.interactionMode3d = mode ?? self.interactionMode3d
                 self.shouldUpdateView = true
             }
             .store(in: &settingsCancelBag)
         settings.$UnitsLength
             .sink {
-                self.lengthPref = $0 ?? self.lengthPref
+                [unowned self] pref in
+                self.lengthPref = pref ?? self.lengthPref
                 self.updateNodes()
             }
             .store(in: &settingsCancelBag)

--- a/CavernSeer/Tabs/ScanListTab/Detail/Renders/GeneralRenderModel.swift
+++ b/CavernSeer/Tabs/ScanListTab/Detail/Renders/GeneralRenderModel.swift
@@ -95,22 +95,23 @@ class GeneralRenderModel : ObservableObject {
     }
 
     func doubleSidedButton() -> some View {
-        Button(action: self.toggleDoubleSided) {
+        Button(action: {
+            [weak self] in
+            self!.doubleSided.toggle()
+            self!.sceneNodes.forEach {
+                [unowned self] in
+                $0.geometry?.firstMaterial?.isDoubleSided = self!.doubleSided
+            }
+            self!.shouldUpdateNodes = true
+            self!.shouldUpdateView = true
+        }) {
+            [unowned self] in
             Image(
                 systemName: self.doubleSided
                     ? "square.on.square"
                     : "square.on.square.dashed"
             )
         }
-    }
-
-    private func toggleDoubleSided() {
-        self.doubleSided = !self.doubleSided
-        sceneNodes.forEach {
-            $0.geometry?.firstMaterial?.isDoubleSided = doubleSided
-        }
-        shouldUpdateNodes = true
-        shouldUpdateView = true
     }
 
     func setSettings(_ settings: SettingsStore) {

--- a/CavernSeer/Tabs/ScanListTab/Detail/Renders/MiniWorldRender.swift
+++ b/CavernSeer/Tabs/ScanListTab/Detail/Renders/MiniWorldRender.swift
@@ -22,8 +22,8 @@ struct MiniWorldRender: View {
 
     var body: some View {
         MiniWorldRenderController(
-            renderModel: _renderModel,
-            snapshotModel: _snapshotModel
+            renderModel: renderModel,
+            snapshotModel: snapshotModel
         )
         .snapshotMenus(for: _snapshotModel)
         .navigationBarItems(trailing: HStack {
@@ -41,17 +41,15 @@ struct MiniWorldRender: View {
 final class MiniWorldRenderController :
     UIViewController, UIViewRepresentable, SCNSceneRendererDelegate {
 
-    @ObservedObject
-    var snapshotModel: SnapshotExportModel
-    @ObservedObject
-    var renderModel: GeneralRenderModel
+    unowned var snapshotModel: SnapshotExportModel
+    unowned var renderModel: GeneralRenderModel
 
     init(
-        renderModel: ObservedObject<GeneralRenderModel>,
-        snapshotModel: ObservedObject<SnapshotExportModel>
+        renderModel: GeneralRenderModel,
+        snapshotModel: SnapshotExportModel
     ) {
-        self._renderModel = renderModel
-        self._snapshotModel = snapshotModel
+        self.renderModel = renderModel
+        self.snapshotModel = snapshotModel
         super.init(nibName: nil, bundle: nil)
     }
 

--- a/CavernSeer/Tabs/ScanListTab/Detail/Renders/PlanProjectedMiniWorldRender.swift
+++ b/CavernSeer/Tabs/ScanListTab/Detail/Renders/PlanProjectedMiniWorldRender.swift
@@ -41,12 +41,12 @@ struct PlanProjectedMiniWorldRender: View {
         VStack {
             PlanProjectedMiniWorldRenderController(
                 height: $height,
-                renderModel: _renderModel,
-                snapshotModel: _snapshotModel,
+                renderModel: renderModel,
+                snapshotModel: snapshotModel,
                 selection: selection,
                 prevSelection: $prevSelection,
                 overlays: overlays,
-                scaleBarModel: $scaleBarModel,
+                scaleBarModel: scaleBarModel,
                 showUI: self.showUI
             )
             if self.showUI {
@@ -62,6 +62,7 @@ struct PlanProjectedMiniWorldRender: View {
             renderModel.doubleSidedButton()
         })
         .onAppear(perform: self.onAppear)
+        .onDisappear(perform: self.onDisappear)
     }
 
     private func onAppear() {
@@ -69,6 +70,10 @@ struct PlanProjectedMiniWorldRender: View {
             self.height = self.initialHeight!
         }
         self.renderModel.updateScanAndSettings(scan: scan, settings: settings)
+    }
+
+    private func onDisappear() {
+        self.renderModel.dismantle()
     }
 
     private var stepperLabel: String {
@@ -99,30 +104,27 @@ final class PlanProjectedMiniWorldRenderController :
     var selectedStation: SurveyStation?
     @Binding
     var prevSelected: SurveyStation?
-    @Binding
-    var scaleBarModel: ScaleBarModel
-    @ObservedObject
-    var snapshotModel: SnapshotExportModel
-    @ObservedObject
-    var renderModel: GeneralRenderModel
+    unowned var scaleBarModel: ScaleBarModel
+    unowned var snapshotModel: SnapshotExportModel
+    unowned var renderModel: GeneralRenderModel
 
     init(
         height: Binding<Int>,
-        renderModel: ObservedObject<GeneralRenderModel>,
-        snapshotModel: ObservedObject<SnapshotExportModel>,
+        renderModel: GeneralRenderModel,
+        snapshotModel: SnapshotExportModel,
         selection: SurveyStation?,
         prevSelection: Binding<SurveyStation?>,
         overlays: [SCNDrawSubview]?,
-        scaleBarModel: Binding<ScaleBarModel>,
+        scaleBarModel: ScaleBarModel,
         showUI: Bool
     ) {
         self._height = height
-        self._renderModel = renderModel
-        self._snapshotModel = snapshotModel
+        self.renderModel = renderModel
+        self.snapshotModel = snapshotModel
         self.selectedStation = selection
         self._prevSelected = prevSelection
         self.overlays = overlays
-        self._scaleBarModel = scaleBarModel
+        self.scaleBarModel = scaleBarModel
         self.showUI = showUI
 
         super.init(nibName: nil, bundle: nil)

--- a/CavernSeer/Tabs/ScanListTab/Detail/Renders/PlanProjectedMiniWorldRender.swift
+++ b/CavernSeer/Tabs/ScanListTab/Detail/Renders/PlanProjectedMiniWorldRender.swift
@@ -62,8 +62,8 @@ struct PlanProjectedMiniWorldRender: View {
             snapshotModel.promptButton(scan: scan)
             renderModel.doubleSidedButton()
         })
-        .onAppear(perform: { self.onAppear() })
-        .onDisappear(perform: { self.onDisappear() })
+        .onAppear(perform: self.onAppear)
+        .onDisappear(perform: self.onDisappear)
     }
 
     private func onAppear() {

--- a/CavernSeer/Tabs/ScanListTab/Detail/Renders/PlanProjectedMiniWorldRender.swift
+++ b/CavernSeer/Tabs/ScanListTab/Detail/Renders/PlanProjectedMiniWorldRender.swift
@@ -58,11 +58,12 @@ struct PlanProjectedMiniWorldRender: View {
         }
         .snapshotMenus(for: _snapshotModel)
         .navigationBarItems(trailing: HStack {
+            [unowned snapshotModel, unowned renderModel] in
             snapshotModel.promptButton(scan: scan)
             renderModel.doubleSidedButton()
         })
-        .onAppear(perform: self.onAppear)
-        .onDisappear(perform: self.onDisappear)
+        .onAppear(perform: { self.onAppear() })
+        .onDisappear(perform: { self.onDisappear() })
     }
 
     private func onAppear() {

--- a/CavernSeer/Tabs/ScanListTab/Detail/SavedScanDetail.swift
+++ b/CavernSeer/Tabs/ScanListTab/Detail/SavedScanDetail.swift
@@ -110,7 +110,7 @@ struct SavedScanDetail: View {
                 secondaryButton: .cancel()
             )
         }
-        .onAppear(perform: { self.loadModel() })
+        .onAppear(perform: self.loadModel)
     }
 
     private func generateObj() {

--- a/CavernSeer/Tabs/ScanListTab/SnapshotExport/SnapshotExportModel.swift
+++ b/CavernSeer/Tabs/ScanListTab/SnapshotExport/SnapshotExportModel.swift
@@ -130,7 +130,7 @@ class SnapshotExportModel : ObservableObject {
     func promptButton(scan: ScanFile) -> some View {
         self.scan = scan
         return Button(action: {
-            [unowned self] in self.promptShowing = true
+            [weak self] in self?.promptShowing = true
         }) {
             Image(systemName: "camera.on.rectangle")
                 .font(Font.system(.title))


### PR DESCRIPTION
I discovered that the two UI models (`GeneralRenderModel` and `SnapshotExportModel`) were being leaked. I started using `weak`s and `unowned`s where I found them to be appropriate to try to prevent recursive references / retain cycles. Also tried to narrow down some references like passing observables where they aren't needed.

Eventually found that the UI connections of each of those models was where they were being retained.