### PR TITLE
Debug work

### DIFF
--- a/CavernSeer.xcodeproj/project.pbxproj
+++ b/CavernSeer.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		7E43C628256B48A800170C17 /* UnitsSettingsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E43C627256B48A800170C17 /* UnitsSettingsSection.swift */; };
 		7E43C62D256B49AB00170C17 /* Interaction3dSettingsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E43C62C256B49AB00170C17 /* Interaction3dSettingsSection.swift */; };
 		7E43C632256B599600170C17 /* SCNInteractionMode+name.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E43C631256B599600170C17 /* SCNInteractionMode+name.swift */; };
+		7E460B9327602B4800BE763D /* DebugSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E460B9227602B4800BE763D /* DebugSection.swift */; };
 		7E4888342557534900894D43 /* ElevationProjectedMiniWorldRender.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E4888332557534900894D43 /* ElevationProjectedMiniWorldRender.swift */; };
 		7E488839255754B200894D43 /* BaseProjectedMiniWorldRender.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E488838255754B200894D43 /* BaseProjectedMiniWorldRender.swift */; };
 		7E5213F42579D1420015FA54 /* RotationControls.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E5213F32579D1420015FA54 /* RotationControls.swift */; };
@@ -168,6 +169,7 @@
 		7E43C627256B48A800170C17 /* UnitsSettingsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnitsSettingsSection.swift; sourceTree = "<group>"; };
 		7E43C62C256B49AB00170C17 /* Interaction3dSettingsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Interaction3dSettingsSection.swift; sourceTree = "<group>"; };
 		7E43C631256B599600170C17 /* SCNInteractionMode+name.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SCNInteractionMode+name.swift"; sourceTree = "<group>"; };
+		7E460B9227602B4800BE763D /* DebugSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugSection.swift; sourceTree = "<group>"; };
 		7E4888332557534900894D43 /* ElevationProjectedMiniWorldRender.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElevationProjectedMiniWorldRender.swift; sourceTree = "<group>"; };
 		7E488838255754B200894D43 /* BaseProjectedMiniWorldRender.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseProjectedMiniWorldRender.swift; sourceTree = "<group>"; };
 		7E5213F32579D1420015FA54 /* RotationControls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RotationControls.swift; sourceTree = "<group>"; };
@@ -364,6 +366,7 @@
 				7E43C627256B48A800170C17 /* UnitsSettingsSection.swift */,
 				7E43C62C256B49AB00170C17 /* Interaction3dSettingsSection.swift */,
 				7E7FD2A6266498DE00F87D08 /* FileSettingsSection.swift */,
+				7E460B9227602B4800BE763D /* DebugSection.swift */,
 			);
 			path = sections;
 			sourceTree = "<group>";
@@ -791,6 +794,7 @@
 				7E99F95324B1161E0098D44B /* SurveyLine.swift in Sources */,
 				7E43C620256B477900170C17 /* ColorsSettingsSection.swift in Sources */,
 				7E7DEEEA25AA28F000320150 /* Double+round.swift in Sources */,
+				7E460B9327602B4800BE763D /* DebugSection.swift in Sources */,
 				7E0C5EFB24CE639E001C0D0E /* FileSaveError.swift in Sources */,
 				7E0C5EF624CE580B001C0D0E /* FileOpener.swift in Sources */,
 				7E23DB2A254E457000BABB52 /* ScaleBarModel.swift in Sources */,

--- a/CavernSeer.xcodeproj/project.pbxproj
+++ b/CavernSeer.xcodeproj/project.pbxproj
@@ -100,6 +100,7 @@
 		7E9CF3D1259D3DDA0036F6F7 /* StoredFileProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E9CF3D0259D3DDA0036F6F7 /* StoredFileProtocol.swift */; };
 		7E9CF3D6259D3DEB0036F6F7 /* SavedStoredFileProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E9CF3D5259D3DEB0036F6F7 /* SavedStoredFileProtocol.swift */; };
 		7E9CF42E259FC4010036F6F7 /* PlanProjectedMiniWorldRender.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E9CF42D259FC4010036F6F7 /* PlanProjectedMiniWorldRender.swift */; };
+		7EAAA3DD2770225600B25CFC /* simd+simd.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EAAA3DC2770225500B25CFC /* simd+simd.swift */; };
 		7EAE9CCD2561B88600EA66D0 /* SettingsTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EAE9CCC2561B88600EA66D0 /* SettingsTabView.swift */; };
 		7EAE9CD52561C6B700EA66D0 /* SettingsKeyEnum.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EAE9CD42561C6B700EA66D0 /* SettingsKeyEnum.swift */; };
 		7EAE9CE92561FF5900EA66D0 /* UserDefaults+color.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EAE9CE82561FF5900EA66D0 /* UserDefaults+color.swift */; };
@@ -231,6 +232,7 @@
 		7E9CF3D0259D3DDA0036F6F7 /* StoredFileProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoredFileProtocol.swift; sourceTree = "<group>"; };
 		7E9CF3D5259D3DEB0036F6F7 /* SavedStoredFileProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SavedStoredFileProtocol.swift; sourceTree = "<group>"; };
 		7E9CF42D259FC4010036F6F7 /* PlanProjectedMiniWorldRender.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlanProjectedMiniWorldRender.swift; sourceTree = "<group>"; };
+		7EAAA3DC2770225500B25CFC /* simd+simd.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "simd+simd.swift"; sourceTree = "<group>"; };
 		7EAE9CCC2561B88600EA66D0 /* SettingsTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsTabView.swift; sourceTree = "<group>"; };
 		7EAE9CD42561C6B700EA66D0 /* SettingsKeyEnum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsKeyEnum.swift; sourceTree = "<group>"; };
 		7EAE9CE82561FF5900EA66D0 /* UserDefaults+color.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+color.swift"; sourceTree = "<group>"; };
@@ -319,6 +321,7 @@
 				7E43C631256B599600170C17 /* SCNInteractionMode+name.swift */,
 				7E7DEEE425AA24CE00320150 /* Float+round.swift */,
 				7E7DEEE925AA28F000320150 /* Double+round.swift */,
+				7EAAA3DC2770225500B25CFC /* simd+simd.swift */,
 			);
 			path = extensions;
 			sourceTree = "<group>";
@@ -780,6 +783,7 @@
 				7E0C5EE124C8F60D001C0D0E /* ProjectListTabView.swift in Sources */,
 				7EAE9CD52561C6B700EA66D0 /* SettingsKeyEnum.swift in Sources */,
 				7E96711826704395002B70B6 /* CSMeshSnapshot.swift in Sources */,
+				7EAAA3DD2770225600B25CFC /* simd+simd.swift in Sources */,
 				7E43C62D256B49AB00170C17 /* Interaction3dSettingsSection.swift in Sources */,
 				7E6C0EF524A9323900129E8C /* ScannerContainerView.swift in Sources */,
 				7E9C2CEA24B3FD5700B9FC44 /* SavedScanRow.swift in Sources */,

--- a/CavernSeer.xcodeproj/project.pbxproj
+++ b/CavernSeer.xcodeproj/project.pbxproj
@@ -1020,7 +1020,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.3.2;
+				MARKETING_VERSION = "0.3.3-dev";
 				PRODUCT_BUNDLE_IDENTIFIER = org.grush.CavernSeer;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTS_MACCATALYST = NO;
@@ -1045,7 +1045,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.3.2;
+				MARKETING_VERSION = "0.3.3-dev";
 				PRODUCT_BUNDLE_IDENTIFIER = org.grush.CavernSeer;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTS_MACCATALYST = NO;

--- a/CavernSeer/Info.plist
+++ b/CavernSeer/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>PlatformTargetPrefix</key>
+	<string>$(SWIFT_PLATFORM_TARGET_PREFIX)</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDocumentTypes</key>

--- a/CavernSeer/Info.plist
+++ b/CavernSeer/Info.plist
@@ -2,7 +2,7 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>PlatformTargetPrefix</key>
+	<key>CS:PlatformTargetPrefix</key>
 	<string>$(SWIFT_PLATFORM_TARGET_PREFIX)</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>

--- a/CavernSeer/Models/ProjectStore.swift
+++ b/CavernSeer/Models/ProjectStore.swift
@@ -34,4 +34,13 @@ final class ProjectStore : StoreProtocol {
     init() {
         (self.dataDirectory, self.cacheDirectory) = self.getOrCreateDirectories()
     }
+
+    func makeErrorCacheInstance(_ url: URL, error: Error) -> ProjectCacheFile {
+        return ProjectCacheFile(
+            realFileURL: url,
+            timestamp: Date(),
+            displayName: "Error: \(error.localizedDescription)",
+            img: nil
+        )
+    }
 }

--- a/CavernSeer/Models/Protocols/StoreProtocol.swift
+++ b/CavernSeer/Models/Protocols/StoreProtocol.swift
@@ -155,6 +155,10 @@ extension StoreProtocol {
             let cacheUrl = cache.getCacheURL(cacheDir: cacheDirectory)
             do {
                 try fileManager.removeItem(at: cacheUrl)
+            } catch {
+                debugPrint("Deleting cacheUrl failed but that's okay", cacheUrl)
+            }
+            do {
                 try fileManager.removeItem(at: dataUrl)
             } catch {
                 fatalError("Deletion failed: \(error.localizedDescription)")

--- a/CavernSeer/Models/Protocols/StoreProtocol.swift
+++ b/CavernSeer/Models/Protocols/StoreProtocol.swift
@@ -33,6 +33,8 @@ protocol StoreProtocol : ObservableObject {
     var modelDataInMemory: [ModelType] { get set }
 
     var caches: [CacheType] { get set }
+
+    func makeErrorCacheInstance(_ url: URL, error: Error) -> CacheType
 }
 
 
@@ -124,8 +126,10 @@ extension StoreProtocol {
                             )
                             newCaches.insert(newDatum, at: offset)
                         } catch {
-                            completion?(error)
-                            return
+//                            completion?(error)
+//                            return
+                            let errCache = self.makeErrorCacheInstance(url, error: error)
+                            newCaches.insert(errCache, at: offset)
                         }
                 }
             }

--- a/CavernSeer/Models/Protocols/StoreProtocol.swift
+++ b/CavernSeer/Models/Protocols/StoreProtocol.swift
@@ -126,8 +126,6 @@ extension StoreProtocol {
                             )
                             newCaches.insert(newDatum, at: offset)
                         } catch {
-//                            completion?(error)
-//                            return
                             let errCache = self.makeErrorCacheInstance(url, error: error)
                             newCaches.insert(errCache, at: offset)
                         }

--- a/CavernSeer/Models/ScanStore.swift
+++ b/CavernSeer/Models/ScanStore.swift
@@ -111,6 +111,16 @@ final class ScanStore : StoreProtocol {
 
         return newUrl
     }
+
+    func makeErrorCacheInstance(_ url: URL, error: Error) -> ScanCacheFile {
+        return ScanCacheFile(
+            realFileURL: url,
+            timestamp: Date.distantFuture,
+            displayName: "Error! \(url.deletingPathExtension().lastPathComponent)",
+            img: nil,
+            error: error
+        )
+    }
 }
 
 

--- a/CavernSeer/Models/ScanStore.swift
+++ b/CavernSeer/Models/ScanStore.swift
@@ -3,7 +3,7 @@
 //  CavernSeer
 //
 //  Created by Samuel Grush on 6/27/20.
-//  Copyright © 2020 Samuel K. Grush. All rights reserved.
+//  Copyright © 2021 Samuel K. Grush. All rights reserved.
 //
 
 import Foundation

--- a/CavernSeer/Models/Serializations/ScanCacheFile.swift
+++ b/CavernSeer/Models/Serializations/ScanCacheFile.swift
@@ -20,18 +20,20 @@ final class ScanCacheFile : NSObject, NSSecureCoding, StoredCacheFileProtocol {
     let id: String
     let timestamp: Date
     let displayName: String
+    let error: Error?
 
     var realFileURL: URL? = nil
 
     let jpegImageData: Data?
 
-    init(realFileURL: URL, timestamp: Date, displayName: String, img: Data?) {
+    init(realFileURL: URL, timestamp: Date, displayName: String, img: Data?, error: Error? = nil) {
         self.encodingVersion = Self.currentEncodingVersion
         self.id = realFileURL.deletingPathExtension().lastPathComponent
         self.timestamp = timestamp
         self.displayName = displayName
         self.realFileURL = realFileURL
         self.jpegImageData = img
+        self.error = error
     }
 
     required init?(coder decoder: NSCoder) {
@@ -41,6 +43,7 @@ final class ScanCacheFile : NSObject, NSSecureCoding, StoredCacheFileProtocol {
                 ? decoder.decodeInt32(forKey: PropertyKeys.version)
                 : 1
         self.encodingVersion = version
+        self.error = nil
 
         if (version == 1) {
             guard
@@ -97,6 +100,7 @@ final class ScanCacheFile : NSObject, NSSecureCoding, StoredCacheFileProtocol {
         self.displayName = id
         self.encodingVersion = Self.currentEncodingVersion
         self.jpegImageData = nil
+        self.error = nil
         self.timestamp = Date()
     }
     #endif

--- a/CavernSeer/Models/Serializations/ScanFile.swift
+++ b/CavernSeer/Models/Serializations/ScanFile.swift
@@ -3,7 +3,7 @@
 //  CavernSeer
 //
 //  Created by Samuel Grush on 6/21/20.
-//  Copyright © 2020 Samuel K. Grush. All rights reserved.
+//  Copyright © 2021 Samuel K. Grush. All rights reserved.
 //
 
 import Foundation
@@ -41,6 +41,8 @@ final class ScanFile : NSObject, NSSecureCoding, StoredFileProtocol {
     let lines: [SurveyLine]
 
     let location: CSLocation?
+
+    let stationPositionDict: [SurveyStation.Identifier: simd_float3]
 
     /**
      * Initializer from an `ARWorldMap` state and `AR` structures during scanning.
@@ -109,6 +111,8 @@ final class ScanFile : NSObject, NSSecureCoding, StoredFileProtocol {
             debugPrint("Unknown failure encoding; \(error)")
             return nil
         }
+
+        self.stationPositionDict = Self.generateStationDict(self.stations)
     }
 
 
@@ -135,6 +139,8 @@ final class ScanFile : NSObject, NSSecureCoding, StoredFileProtocol {
         self.stations = stations
         self.lines = lines
         self.location = location
+
+        self.stationPositionDict = Self.generateStationDict(self.stations)
     }
 
     func encode(with coder: NSCoder) {
@@ -171,6 +177,8 @@ final class ScanFile : NSObject, NSSecureCoding, StoredFileProtocol {
 
         self.location = nil
 
+        self.stationPositionDict = Self.generateStationDict(self.stations)
+
         super.init()
     }
     #endif
@@ -193,6 +201,23 @@ final class ScanFile : NSObject, NSSecureCoding, StoredFileProtocol {
             displayName: name,
             img: img
         )
+    }
+
+    func getDistance(line: SurveyLine, lengthPref: LengthPreference) -> String {
+        return line.getDistance(
+            stationDict: stationPositionDict,
+            lengthPref: lengthPref
+        )
+    }
+
+    private static func generateStationDict(
+        _ stations: [SurveyStation]
+    ) -> [SurveyStation.Identifier: simd_float3] {
+        var dict = [SurveyStation.Identifier: simd_float3]()
+        stations.forEach {
+            dict[$0.identifier] = $0.transform.toPosition()
+        }
+        return dict
     }
 }
 

--- a/CavernSeer/Models/Serializations/SurveyLine.swift
+++ b/CavernSeer/Models/Serializations/SurveyLine.swift
@@ -3,7 +3,7 @@
 //  CavernSeer
 //
 //  Created by Samuel Grush on 7/4/20.
-//  Copyright © 2020 Samuel K. Grush. All rights reserved.
+//  Copyright © 2021 Samuel K. Grush. All rights reserved.
 //
 
 import Foundation
@@ -50,6 +50,24 @@ final class SurveyLine: NSObject, NSSecureCoding {
 
 
 extension SurveyLine {
+    func getDistance(
+        stationDict: [SurveyStation.Identifier: simd_float3],
+        lengthPref: LengthPreference
+    ) -> String {
+        guard
+            let start = stationDict[self.startIdentifier],
+            let end = stationDict[self.endIdentifier]
+        else {
+            fatalError("SurveyLine.toSCNNode start/end not in dict")
+        }
+
+        return getDistanceString(
+            start,
+            end,
+            lengthPref: lengthPref
+        )
+    }
+
     func toSCNNode(
         stationDict: [SurveyStation.Identifier:SCNNode],
         lengthPref: LengthPreference

--- a/CavernSeer/Tabs/ScanListTab/Detail/SavedScanDetail.swift
+++ b/CavernSeer/Tabs/ScanListTab/Detail/SavedScanDetail.swift
@@ -19,6 +19,9 @@ struct SavedScanDetail: View {
     var scanStore: ScanStore
 
     @State
+    var error: Error?
+
+    @State
     private var model: SavedScanModel? = nil
     @State
     private var isPresentingRender = false
@@ -38,6 +41,11 @@ struct SavedScanDetail: View {
     private var fileExt = "obj"
 
     private func loadModel() {
+        if let err = self.cache.error {
+            self.error = err
+            return
+        }
+
         let url = scanStore.getNormalizedRealUrl(cache: self.cache)
         if self.model?.url != url {
             do {
@@ -67,7 +75,7 @@ struct SavedScanDetail: View {
 
             Spacer()
 
-            Text(model?.id ?? "Loading...")
+            Text(model?.id ?? error?.localizedDescription ?? "Loading...")
                 .font(.title)
                 .padding()
 

--- a/CavernSeer/Tabs/ScanListTab/Detail/SavedScanDetail.swift
+++ b/CavernSeer/Tabs/ScanListTab/Detail/SavedScanDetail.swift
@@ -3,7 +3,7 @@
 //  CavernSeer
 //
 //  Created by Samuel Grush on 7/6/20.
-//  Copyright © 2020 Samuel K. Grush. All rights reserved.
+//  Copyright © 2021 Samuel K. Grush. All rights reserved.
 //
 
 import SwiftUI /// View

--- a/CavernSeer/Tabs/ScanListTab/Detail/SavedScanDetailAdvanced.swift
+++ b/CavernSeer/Tabs/ScanListTab/Detail/SavedScanDetailAdvanced.swift
@@ -53,7 +53,10 @@ struct SavedScanDetailAdvanced: View {
                 List(model.scan.meshAnchors, id: \.identifier) {
                     anchor in
                     NavigationLink(
-                        destination: MeshAnchorDetail(anchor: anchor)
+                        destination: MeshAnchorDetail(
+                            anchor: anchor,
+                            xyzView: xyzView
+                        )
                     ) {
                         HStack {
                             Text(anchor.description)
@@ -69,7 +72,7 @@ struct SavedScanDetailAdvanced: View {
                     station in
                     HStack {
                         Text(station.identifier.uuidString)
-                        Text(station.transform.debugDescription)
+                        xyzView(model.scan.stationPositionDict[station.identifier]!)
                     }
                 }
             }
@@ -81,6 +84,10 @@ struct SavedScanDetailAdvanced: View {
                     HStack {
                         Text(line.startIdentifier.uuidString)
                         Text(line.endIdentifier.uuidString)
+                        Text(model.scan.getDistance(
+                            line: line,
+                            lengthPref: unitLength
+                        ))
                     }
                 }
             }
@@ -168,6 +175,7 @@ struct SavedScanDetailAdvanced: View {
 
 struct MeshAnchorDetail: View {
     var anchor: CSMeshSlice
+    var xyzView: (simd_float3) -> AnyView
 
     var body: some View {
         VStack {
@@ -175,6 +183,10 @@ struct MeshAnchorDetail: View {
                 .font(.title)
             VStack {
                 Text("transform: \(anchor.transform.debugDescription)")
+                HStack {
+                    Text("position:")
+                    xyzView(anchor.transform.toPosition())
+                }
                 Text("Vertex count: \(anchor.vertices.count)")
                 Text("Normal count: \(anchor.normals.count)")
                 Text("Face count: \(anchor.faces.count)")

--- a/CavernSeer/Tabs/ScanListTab/Detail/SavedScanDetailAdvanced.swift
+++ b/CavernSeer/Tabs/ScanListTab/Detail/SavedScanDetailAdvanced.swift
@@ -3,7 +3,7 @@
 //  CavernSeer
 //
 //  Created by Samuel Grush on 7/7/20.
-//  Copyright © 2020 Samuel K. Grush. All rights reserved.
+//  Copyright © 2021 Samuel K. Grush. All rights reserved.
 //
 
 import SwiftUI /// View

--- a/CavernSeer/Tabs/ScanListTab/SavedScanRow.swift
+++ b/CavernSeer/Tabs/ScanListTab/SavedScanRow.swift
@@ -30,7 +30,12 @@ struct SavedScanRow: View {
 
     init(cache: ScanCacheFile, image: Image? = nil) {
         self.cache = cache
-        self.image = image ?? makeSnapshot(data: cache.jpegImageData)
+
+        if cache.error == nil {
+            self.image = image ?? makeSnapshot(data: cache.jpegImageData)
+        } else {
+            self.image = Image(systemName: "exclamationmark.triangle")
+        }
     }
 
     private func makeSnapshot(data: Data?) -> Image? {

--- a/CavernSeer/Tabs/ScanListTab/SavedScanRow.swift
+++ b/CavernSeer/Tabs/ScanListTab/SavedScanRow.swift
@@ -3,7 +3,7 @@
 //  CavernSeer
 //
 //  Created by Samuel Grush on 7/6/20.
-//  Copyright © 2020 Samuel K. Grush. All rights reserved.
+//  Copyright © 2021 Samuel K. Grush. All rights reserved.
 //
 
 import SwiftUI /// View

--- a/CavernSeer/Tabs/SettingsTab/SettingsTabView.swift
+++ b/CavernSeer/Tabs/SettingsTab/SettingsTabView.swift
@@ -3,7 +3,7 @@
 //  CavernSeer
 //
 //  Created by Samuel Grush on 11/15/20.
-//  Copyright © 2020 Samuel K. Grush. All rights reserved.
+//  Copyright © 2021 Samuel K. Grush. All rights reserved.
 //
 
 import SwiftUI
@@ -48,6 +48,10 @@ struct SettingsTabView: View {
 
                 Section(header: Text("Files")) {
                     FileSettingsSection()
+                }
+
+                Section(header: Text("Debug")) {
+                    DebugSection()
                 }
             }
         }

--- a/CavernSeer/Tabs/SettingsTab/sections/DebugSection.swift
+++ b/CavernSeer/Tabs/SettingsTab/sections/DebugSection.swift
@@ -1,0 +1,54 @@
+//
+//  DebugSection.swift
+//  CavernSeer
+//
+//  Created by Samuel Grush on 12/7/21.
+//  Copyright © 2021 Samuel K. Grush. All rights reserved.
+//
+
+import SwiftUI
+
+struct DebugSection: View {
+
+    private static let githubURL = URL(string: "https://cavernseer.grush.org/github")!
+
+    let keys = [
+        ("CFBundleShortVersionString", "Version"),
+        ("CFBundleVersion", "Build"),
+        ("PlatformTargetPrefix", "Platform Target"),
+        ("MinimumOSVersion", "MinimumOSVersion"),
+
+    ]
+
+    var body: some View {
+        Group() {
+
+            ForEach(keys, id: \.1) {
+                (key, label) in
+                HStack {
+                    Text(label).fontWeight(.light)
+                    Spacer()
+                    Text(getInfo(key: key))
+                }
+            }
+
+            HStack {
+                Text("View source").fontWeight(.light)
+                Spacer()
+                Link("GitHub", destination: Self.githubURL)
+            }
+        }
+    }
+
+    private func getInfo(key: String) -> String {
+        Bundle.main.infoDictionary?[key] as? String ?? "Error"
+    }
+}
+
+#if DEBUG
+struct DebugSection_Previews: PreviewProvider {
+    static var previews: some View {
+        DebugSection()
+    }
+}
+#endif

--- a/CavernSeer/Tabs/SettingsTab/sections/DebugSection.swift
+++ b/CavernSeer/Tabs/SettingsTab/sections/DebugSection.swift
@@ -15,7 +15,7 @@ struct DebugSection: View {
     let keys = [
         ("CFBundleShortVersionString", "Version"),
         ("CFBundleVersion", "Build"),
-        ("PlatformTargetPrefix", "Platform Target"),
+        ("CS:PlatformTargetPrefix", "Platform Target"),
         ("MinimumOSVersion", "MinimumOSVersion"),
 
     ]

--- a/CavernSeer/extensions/simd+simd.swift
+++ b/CavernSeer/extensions/simd+simd.swift
@@ -1,0 +1,21 @@
+//
+//  simd+simd.swift
+//  CavernSeer
+//
+//  Created by Samuel Grush on 12/19/21.
+//  Copyright © 2021 Samuel K. Grush. All rights reserved.
+//
+
+import Foundation
+import ARKit
+
+extension simd_float4x4 {
+    func toPosition() -> simd_float3 {
+        let col = self.columns.3
+        return .init(
+            col.x,
+            col.y,
+            col.z
+        )
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <img src="/docs/icons/icon-167.png" align="right">
 
-#  CavernSeer v0.3.2
+#  CavernSeer v0.3.3-dev
 > An iPadOS and iOS application for scanning 3D spaces
 
 Designed for cave and shelter surveying, CavernSeer leverages the LiDAR scanner of the 2020 iPad Pro and the iPhone 12 Pro, and RealityKit's scene reconstruction, to generate relatively-accurate 3D meshes of real-world spaces and render them in various convenient ways.


### PR DESCRIPTION
* Bump to 0.3.3-dev
* Actual debug work
   * Catch errors during opening ScanFiles and ScanCacheFiles when opening caches; prevents the list from entirely failing when an error happens
      - show error icon in scan list
      - show error message in the scan details
   * Allow deleting a cache to fail (e.g. if the file doesn't actually exist) when deleting a scan. Could this maybe cause a memory leak?
   * Debug section in settings, including version, build, platform target, minimum OS version, and GitHub link
* advanced position details
   - display localized XYZ positions for anchors and stations
   - display line lengths
   - caching of station identifier:position relationships on ScanFiles